### PR TITLE
docs: list python-posthorn in client ecosystem

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -15,4 +15,8 @@ To propose a project for this list, see the listing criteria in
 
 ## Client libraries
 
-No community client libraries are listed yet. See [CONTRIBUTING](../CONTRIBUTING.md#community-projects) to propose one.
+| Project | Language | License | Description |
+| --- | --- | --- | --- |
+| [python-posthorn](https://github.com/monperrus/python-posthorn) | Python | MIT | Zero-dependency client for Posthorn's HTTP API. |
+
+See [CONTRIBUTING](../CONTRIBUTING.md#community-projects) to propose another.


### PR DESCRIPTION
## Summary
- Adds an entry for [python-posthorn](https://github.com/monperrus/python-posthorn) to the new Client libraries table in `docs/ecosystem.md`, per the listing criteria in CONTRIBUTING.md#community-projects.

Follow-up to #46 — per the maintainer's request there, the PyPI package now sets `project_urls.Source` to the GitHub repo (https://pypi.org/project/python-posthorn/).

## Checklist (per listing criteria)
- [x] Public source repository: https://github.com/monperrus/python-posthorn
- [x] OSI-approved license: MIT
- [x] Name does not imply official status
- [x] Versioned release (currently 0.6.0 on PyPI) and active history