### PR TITLE
fix(transport): share FR19-22 retry policy with the SMTP ingress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The "originally v1.x" labels are preserved as block A/B/C/D inside v1.0 for hist
 
 **Architecture deviations from original spec (cumulative):**
 - `core/http/` → `core/gateway/` to avoid shadowing stdlib `net/http`.
-- Retry timing constants declared as package vars (not consts) so tests can override via `gateway.SetRetryDelaysForTest`.
+- Retry timing constants declared as package vars (not consts) so tests can override via `gateway.SetRetryDelaysForTest`. **2026-07-03 (#59):** the FR19-22 policy itself moved to `transport.SendWithRetry`, shared by both ingresses — previously the SMTP session called `Send` directly and skipped retries. The gateway test hook keeps its API and now sets `transport.TransientRetryDelay`/`RateLimitedRetryDelay`.
 - [`site/`](./site/) Astro + Starlight directory; deploys via [`.github/workflows/site-deploy.yml`](./.github/workflows/site-deploy.yml). Build: `cd site && npm ci && npm run build`.
 - **2026-05-15:** Caddy v2 adapter module cut. FR27–FR30, NFR10 deleted; ADR-6, ADR-7 retired in-place.
 - **2026-05-15:** Honeypot 200 response shape parity (commit `0f27f4c`).

--- a/core/gateway/export_test.go
+++ b/core/gateway/export_test.go
@@ -1,20 +1,26 @@
 package gateway
 
-import "time"
+import (
+	"time"
 
-// SetRetryDelaysForTest swaps the package-level retry/timeout variables
-// to short values for tests, returning a function that restores them.
+	"github.com/craigmccaskill/posthorn/transport"
+)
+
+// SetRetryDelaysForTest swaps the retry/timeout variables to short
+// values for tests, returning a function that restores them. The retry
+// delays live in the transport package since the FR19-22 policy moved
+// to transport.SendWithRetry (issue #59); requestTimeout stays here.
 //
 // Compiled only with _test.go files. External (gateway_test package)
 // tests use this rather than reaching into unexported state directly.
 func SetRetryDelaysForTest(transient, rateLimited, requestTO time.Duration) func() {
-	oldT, oldR, oldTo := transientRetryDelay, rateLimitedRetryDelay, requestTimeout
-	transientRetryDelay = transient
-	rateLimitedRetryDelay = rateLimited
+	oldT, oldR, oldTo := transport.TransientRetryDelay, transport.RateLimitedRetryDelay, requestTimeout
+	transport.TransientRetryDelay = transient
+	transport.RateLimitedRetryDelay = rateLimited
 	requestTimeout = requestTO
 	return func() {
-		transientRetryDelay = oldT
-		rateLimitedRetryDelay = oldR
+		transport.TransientRetryDelay = oldT
+		transport.RateLimitedRetryDelay = oldR
 		requestTimeout = oldTo
 	}
 }

--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -46,22 +46,12 @@ const defaultEmailField = "email"
 // overridable — see ADR-11 for the safety reasoning.
 const toOverrideField = "to_override"
 
-// Retry timing — declared as vars so tests can override without
-// waiting full real-time delays. Production never mutates these.
-var (
-	// requestTimeout is the hard upper bound on a single submission's
-	// processing time, including any retries (FR22).
-	requestTimeout = 10 * time.Second
-
-	// transientRetryDelay is how long the handler waits before retrying
-	// a transient transport failure (FR19).
-	transientRetryDelay = 1 * time.Second
-
-	// rateLimitedRetryDelay is how long the handler waits before retrying
-	// a 429 from the upstream provider (FR20). Longer than transient
-	// because the upstream is asking us to slow down.
-	rateLimitedRetryDelay = 5 * time.Second
-)
+// requestTimeout is the hard upper bound on a single submission's
+// processing time, including any retries (FR22). Declared as a var so
+// tests can override; production never mutates it. The retry delays
+// themselves live in the transport package (transport.SendWithRetry),
+// shared with the SMTP ingress per issue #59.
+var requestTimeout = 10 * time.Second
 
 // Handler accepts form submissions and forwards them via a Transport.
 //
@@ -598,7 +588,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), requestTimeout)
 	defer cancel()
 
-	result, err := sendWithRetry(ctx, h.transport, msg, logger)
+	result, err := transport.SendWithRetry(ctx, h.transport, msg, logger)
 	if err != nil {
 		// Terminal failure — log payload (or just metadata if operator
 		// disabled it) so operators can recover from logs (FR16).
@@ -786,64 +776,6 @@ func (h *Handler) authenticateAPIRequest(r *http.Request) (string, bool) {
 		}
 	}
 	return matched, matched != ""
-}
-
-// sendWithRetry implements the FR19-22 retry policy:
-//
-//   - On *transport.TransportError with class ErrTransient: wait 1s, retry once.
-//   - On *transport.TransportError with class ErrRateLimited: wait 5s, retry once.
-//   - On any class ErrTerminal (or non-TransportError): no retry.
-//   - The provided ctx carries the 10s request hard timeout (FR22);
-//     if it expires during the backoff, the second attempt is skipped.
-//
-// Returns the transport result and nil on success, or a zero result and the
-// most recent TransportError on failure.
-func sendWithRetry(ctx context.Context, t transport.Transport, msg transport.Message, logger *slog.Logger) (transport.SendResult, error) {
-	result, err := t.Send(ctx, msg)
-	if err == nil {
-		return result, nil
-	}
-
-	var te *transport.TransportError
-	if !errors.As(err, &te) {
-		// Non-TransportError — caller contract violation; treat as terminal.
-		return transport.SendResult{}, err
-	}
-
-	var delay time.Duration
-	switch te.Class {
-	case transport.ErrTransient:
-		delay = transientRetryDelay
-	case transport.ErrRateLimited:
-		delay = rateLimitedRetryDelay
-	default:
-		// ErrTerminal, ErrUnknown — no retry.
-		return transport.SendResult{}, err
-	}
-
-	logger.Info("send_retry_scheduled",
-		slog.String("class", te.Class.String()),
-		slog.Int("status", te.Status),
-		slog.Duration("delay", delay),
-	)
-
-	select {
-	case <-ctx.Done():
-		// Hit the 10s hard timeout before we could retry. Surface the
-		// original error.
-		return transport.SendResult{}, err
-	case <-time.After(delay):
-	}
-
-	retryResult, retryErr := t.Send(ctx, msg)
-	if retryErr == nil {
-		logger.Info("send_retry_succeeded")
-		return retryResult, nil
-	}
-	logger.Info("send_retry_failed",
-		slog.String("error", retryErr.Error()),
-	)
-	return transport.SendResult{}, retryErr
 }
 
 // redactedForm returns a copy of the form with the honeypot field

--- a/core/smtp/listener_test.go
+++ b/core/smtp/listener_test.go
@@ -31,12 +31,22 @@ type mockTransport struct {
 	sent   []transport.Message
 	result transport.SendResult
 	err    error
+
+	// errQueue, when non-empty, overrides err: each Send pops the head
+	// and returns it (nil = success). Lets retry tests script
+	// fail-then-succeed sequences.
+	errQueue []error
 }
 
 func (m *mockTransport) Send(_ context.Context, msg transport.Message) (transport.SendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sent = append(m.sent, msg)
+	if len(m.errQueue) > 0 {
+		e := m.errQueue[0]
+		m.errQueue = m.errQueue[1:]
+		return m.result, e
+	}
 	return m.result, m.err
 }
 
@@ -734,6 +744,64 @@ func TestSMTP_AuthNone_HappyPath_DeliversMessage(t *testing.T) {
 // prevention layer survives even when auth is disabled. AllowedSenders
 // is the only thing standing between the listener and a true open relay
 // in this mode, so the test is load-bearing.
+// --- FR19-22 retry policy on the SMTP path (issue #59) ---
+
+// smtpDataFlow drives EHLO/AUTH/MAIL/RCPT/DATA against the fixture and
+// returns the response code to the end-of-DATA dot.
+func smtpDataFlow(t *testing.T, f *smtpFixture) int {
+	t.Helper()
+	tp := f.dial()
+	_ = tp.PrintfLine("EHLO client.test")
+	expectMultiline(t, tp, 250)
+	_ = tp.PrintfLine("AUTH PLAIN %s", authPlainCreds("user", "pass"))
+	expect(t, tp, 235)
+	_ = tp.PrintfLine("MAIL FROM:<noreply@example.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("RCPT TO:<alice@somewhere.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("DATA")
+	expect(t, tp, 354)
+	_ = tp.PrintfLine("Subject: Hello\r\n\r\nBody.\r\n.")
+	code, _ := expectCode(t, tp)
+	return code
+}
+
+func TestSMTP_TransientUpstream_RetriesOnce_Succeeds(t *testing.T) {
+	// One transient failure then success must yield 250 with two Send
+	// calls — the same FR19 retry the HTTP path applies. Before #59
+	// the SMTP path returned an immediate 451 here.
+	oldDelay := transport.TransientRetryDelay
+	transport.TransientRetryDelay = time.Millisecond
+	t.Cleanup(func() { transport.TransientRetryDelay = oldDelay })
+
+	f := startListener(t, baseTestConfig())
+	f.mt.errQueue = []error{
+		&transport.TransportError{Class: transport.ErrTransient, Status: 503, Message: "blip"},
+	}
+	if code := smtpDataFlow(t, f); code != 250 {
+		t.Fatalf("DATA response = %d, want 250 after transient retry", code)
+	}
+	waitForSend(t, f.mt, 2, 500*time.Millisecond)
+	if got := len(f.mt.Sent()); got != 2 {
+		t.Errorf("Send calls = %d, want 2 (original + one retry)", got)
+	}
+}
+
+func TestSMTP_TerminalUpstream_NoRetry_451(t *testing.T) {
+	// Terminal errors don't retry (FR21): one Send call, 451 to the
+	// client.
+	f := startListener(t, baseTestConfig())
+	f.mt.errQueue = []error{
+		&transport.TransportError{Class: transport.ErrTerminal, Status: 422, Message: "bad payload"},
+	}
+	if code := smtpDataFlow(t, f); code != 451 {
+		t.Fatalf("DATA response = %d, want 451 on terminal upstream error", code)
+	}
+	if got := len(f.mt.Sent()); got != 1 {
+		t.Errorf("Send calls = %d, want 1 (no retry on terminal)", got)
+	}
+}
+
 func TestSMTP_AuthNone_SenderAllowlist_StillEnforced(t *testing.T) {
 	cfg := baseTestConfig()
 	cfg.AuthRequired = AuthNone

--- a/core/smtp/session.go
+++ b/core/smtp/session.go
@@ -19,6 +19,12 @@ import (
 	"github.com/craigmccaskill/posthorn/transport"
 )
 
+// sendTimeout is the hard upper bound on a single DATA submission's
+// outbound send, including any retries — the same FR22 bound the HTTP
+// gateway applies via its requestTimeout. Declared as a var so tests
+// can override; production never mutates it.
+var sendTimeout = 10 * time.Second
+
 // session is the per-connection SMTP state machine.
 //
 // State transitions (RFC 5321-shaped, simplified to what Posthorn needs):
@@ -364,11 +370,15 @@ func (s *session) handleDATA() {
 		return
 	}
 
-	// Hand off to the outbound transport.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Hand off to the outbound transport. SendWithRetry applies the
+	// FR19-22 retry policy (one retry on transient/429), shared with
+	// the HTTP ingress per ADR-12's ingress-agnostic egress (issue
+	// #59); previously the SMTP path called Send directly and returned
+	// an immediate 451 on errors the HTTP path would have retried.
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 	submissionID := uuid.NewString()
-	result, sendErr := s.l.transport.Send(ctx, msg)
+	result, sendErr := transport.SendWithRetry(ctx, s.l.transport, msg, s.logger)
 	if sendErr != nil {
 		_ = s.writeReply(451, "4.0.0 Upstream transport failed")
 		s.logger.Error("smtp_submission_failed",

--- a/core/transport/retry.go
+++ b/core/transport/retry.go
@@ -1,0 +1,87 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+)
+
+// Retry timing — declared as vars so tests can override without
+// waiting full real-time delays. Production never mutates these.
+//
+// The policy lived in core/gateway through v1.0, which made FR19-22
+// silently HTTP-only: the SMTP session called Send directly, so a
+// transient provider error got one retry on the HTTP path but an
+// immediate 451 on the SMTP path. Moving the policy here makes ADR-12's
+// "the egress side (Transport, retry policy, structured logging) is
+// ingress-agnostic" claim true, and is the seam the v2 async queue
+// wraps per ADR-5 (issue #59).
+var (
+	// TransientRetryDelay is how long SendWithRetry waits before
+	// retrying a transient transport failure (FR19).
+	TransientRetryDelay = 1 * time.Second
+
+	// RateLimitedRetryDelay is how long SendWithRetry waits before
+	// retrying a 429 from the upstream provider (FR20). Longer than
+	// transient because the upstream is asking us to slow down.
+	RateLimitedRetryDelay = 5 * time.Second
+)
+
+// SendWithRetry implements the FR19-22 retry policy:
+//
+//   - On *TransportError with class ErrTransient: wait 1s, retry once.
+//   - On *TransportError with class ErrRateLimited: wait 5s, retry once.
+//   - On any class ErrTerminal (or non-TransportError): no retry.
+//   - The provided ctx carries the caller's hard timeout (FR22);
+//     if it expires during the backoff, the second attempt is skipped.
+//
+// Returns the transport result and nil on success, or a zero result and the
+// most recent TransportError on failure.
+func SendWithRetry(ctx context.Context, t Transport, msg Message, logger *slog.Logger) (SendResult, error) {
+	result, err := t.Send(ctx, msg)
+	if err == nil {
+		return result, nil
+	}
+
+	var te *TransportError
+	if !errors.As(err, &te) {
+		// Non-TransportError — caller contract violation; treat as terminal.
+		return SendResult{}, err
+	}
+
+	var delay time.Duration
+	switch te.Class {
+	case ErrTransient:
+		delay = TransientRetryDelay
+	case ErrRateLimited:
+		delay = RateLimitedRetryDelay
+	default:
+		// ErrTerminal, ErrUnknown — no retry.
+		return SendResult{}, err
+	}
+
+	logger.Info("send_retry_scheduled",
+		slog.String("class", te.Class.String()),
+		slog.Int("status", te.Status),
+		slog.Duration("delay", delay),
+	)
+
+	select {
+	case <-ctx.Done():
+		// Hit the hard timeout before we could retry. Surface the
+		// original error.
+		return SendResult{}, err
+	case <-time.After(delay):
+	}
+
+	retryResult, retryErr := t.Send(ctx, msg)
+	if retryErr == nil {
+		logger.Info("send_retry_succeeded")
+		return retryResult, nil
+	}
+	logger.Info("send_retry_failed",
+		slog.String("error", retryErr.Error()),
+	)
+	return SendResult{}, retryErr
+}

--- a/core/transport/retry_test.go
+++ b/core/transport/retry_test.go
@@ -1,0 +1,131 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// scriptedTransport returns the queued errors in order, then succeeds.
+type scriptedTransport struct {
+	calls int
+	errs  []error
+}
+
+func (s *scriptedTransport) Send(_ context.Context, _ Message) (SendResult, error) {
+	s.calls++
+	if len(s.errs) > 0 {
+		e := s.errs[0]
+		s.errs = s.errs[1:]
+		if e != nil {
+			return SendResult{}, e
+		}
+	}
+	return SendResult{MessageID: "ok"}, nil
+}
+
+func shortDelays(t *testing.T) {
+	t.Helper()
+	oldT, oldR := TransientRetryDelay, RateLimitedRetryDelay
+	TransientRetryDelay = time.Millisecond
+	RateLimitedRetryDelay = time.Millisecond
+	t.Cleanup(func() {
+		TransientRetryDelay = oldT
+		RateLimitedRetryDelay = oldR
+	})
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+func TestSendWithRetry_TransientThenSuccess(t *testing.T) {
+	shortDelays(t)
+	st := &scriptedTransport{errs: []error{
+		&TransportError{Class: ErrTransient, Status: 503, Message: "blip"},
+	}}
+	result, err := SendWithRetry(context.Background(), st, Message{}, discardLogger())
+	if err != nil {
+		t.Fatalf("err = %v, want nil after retry", err)
+	}
+	if st.calls != 2 {
+		t.Errorf("calls = %d, want 2", st.calls)
+	}
+	if result.MessageID != "ok" {
+		t.Errorf("MessageID = %q", result.MessageID)
+	}
+}
+
+func TestSendWithRetry_RateLimitedThenSuccess(t *testing.T) {
+	shortDelays(t)
+	st := &scriptedTransport{errs: []error{
+		&TransportError{Class: ErrRateLimited, Status: 429, Message: "slow down"},
+	}}
+	if _, err := SendWithRetry(context.Background(), st, Message{}, discardLogger()); err != nil {
+		t.Fatalf("err = %v, want nil after retry", err)
+	}
+	if st.calls != 2 {
+		t.Errorf("calls = %d, want 2", st.calls)
+	}
+}
+
+func TestSendWithRetry_Terminal_NoRetry(t *testing.T) {
+	shortDelays(t)
+	terminal := &TransportError{Class: ErrTerminal, Status: 422, Message: "bad payload"}
+	st := &scriptedTransport{errs: []error{terminal}}
+	_, err := SendWithRetry(context.Background(), st, Message{}, discardLogger())
+	if !errors.Is(err, terminal) {
+		t.Fatalf("err = %v, want the terminal error", err)
+	}
+	if st.calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retry on terminal)", st.calls)
+	}
+}
+
+func TestSendWithRetry_NonTransportError_NoRetry(t *testing.T) {
+	shortDelays(t)
+	plain := errors.New("caller contract violation")
+	st := &scriptedTransport{errs: []error{plain}}
+	_, err := SendWithRetry(context.Background(), st, Message{}, discardLogger())
+	if !errors.Is(err, plain) {
+		t.Fatalf("err = %v, want the plain error", err)
+	}
+	if st.calls != 1 {
+		t.Errorf("calls = %d, want 1", st.calls)
+	}
+}
+
+func TestSendWithRetry_BothAttemptsFail_ReturnsSecondError(t *testing.T) {
+	shortDelays(t)
+	first := &TransportError{Class: ErrTransient, Status: 503, Message: "blip one"}
+	second := &TransportError{Class: ErrTransient, Status: 503, Message: "blip two"}
+	st := &scriptedTransport{errs: []error{first, second}}
+	_, err := SendWithRetry(context.Background(), st, Message{}, discardLogger())
+	if !errors.Is(err, second) {
+		t.Fatalf("err = %v, want the second attempt's error", err)
+	}
+	if st.calls != 2 {
+		t.Errorf("calls = %d, want 2 (one retry, then stop)", st.calls)
+	}
+}
+
+func TestSendWithRetry_ContextExpiredDuringBackoff_SkipsRetry(t *testing.T) {
+	// Long delay + already-cancelled ctx: the backoff select must take
+	// the ctx branch and surface the original error without a second
+	// Send.
+	oldT := TransientRetryDelay
+	TransientRetryDelay = time.Hour
+	t.Cleanup(func() { TransientRetryDelay = oldT })
+
+	original := &TransportError{Class: ErrTransient, Status: 503, Message: "blip"}
+	st := &scriptedTransport{errs: []error{original}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := SendWithRetry(ctx, st, Message{}, discardLogger())
+	if !errors.Is(err, original) {
+		t.Fatalf("err = %v, want the original error", err)
+	}
+	if st.calls != 1 {
+		t.Errorf("calls = %d, want 1 (retry skipped on expired ctx)", st.calls)
+	}
+}

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -74,6 +74,7 @@ posthorn/
     │   └── handler_test.go
     ├── transport/
     │   ├── transport.go          # Transport interface, Message, ErrorClass, TransportError
+    │   ├── retry.go              # SendWithRetry: FR19-22 policy, shared by both ingresses (#59)
     │   ├── postmark.go           # Postmark HTTP API implementation
     │   ├── resend.go             # v1.0 block C: Resend HTTP API (FR47)
     │   ├── mailgun.go            # v1.0 block C: Mailgun HTTP API (FR48)


### PR DESCRIPTION
## Summary

Resolves #59 with option 1 from the issue: `sendWithRetry` moves from `core/gateway` to `transport.SendWithRetry`, and the SMTP session calls it instead of `Send` directly.

Why it matters: a transient provider error got one retry on the HTTP path but an immediate 451 on the SMTP path. Real app mailers vary on 451 handling — Ghost logs the failure and moves on — so a provider blip became a lost password-reset email on exactly the path the recipes advertise. This also makes ADR-12's "egress is ingress-agnostic" claim true and creates the ADR-5 seam the v2 async queue wraps.

Mechanics:
- Retry delays become `transport` package vars; `gateway.SetRetryDelaysForTest` keeps its API (now delegating)
- SMTP's hardcoded 10s send timeout becomes the documented `sendTimeout` var (FR22 bound)
- New `transport/retry_test.go` covers the policy directly; new SMTP-level tests assert retry-then-250 and terminal-451-no-retry

Note: CHANGELOG entry deliberately omitted to avoid colliding with #49's Unreleased section — will add on merge/release.

## Test plan

- [x] `go vet ./...` + `go test -race -count=1 ./...` — all 14 test packages pass
- [x] New unit tests: transient/rate-limited/terminal/non-TransportError/double-failure/ctx-expiry
- [x] New SMTP integration tests through the real socket fixture

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)