### PR TITLE
ci: lint/vuln/fmt gates, digest-pinned bases, signed + scanned releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Keeps the digest-pinned base images (#39), Go module deps, and GitHub
+# Actions versions fresh via weekly PRs.
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /core
+    schedule:
+      interval: weekly
+    # Digest pins update in place; the tag comment stays for humans.
+
+  - package-ecosystem: gomod
+    directory: /core
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,40 @@ jobs:
       - name: Verify modules
         run: go mod verify
 
+      - name: gofmt gate
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "gofmt needed on:" >&2
+            echo "$unformatted" >&2
+            exit 1
+          fi
+
       - name: Vet
         run: go vet ./...
 
       - name: Test
         run: go test -race -count=1 -timeout=2m ./...
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: core/go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          working-directory: core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # cosign keyless signing via GitHub OIDC (#56)
 
 env:
   REGISTRY: ghcr.io
@@ -54,6 +55,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ./core
@@ -64,10 +66,31 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.ref_name }}
-          # Traditional multi-arch manifest; skip SLSA provenance / SBOM
-          # attestations which add manifest entries that some tools
-          # mishandle. Can layer cosign signing on later if needed.
-          provenance: false
-          sbom: false
+          # SLSA provenance + SBOM attestations (#56). These add OCI
+          # attestation manifests to the index; modern registries and
+          # tooling handle them. Self-hosters can verify with
+          # `cosign verify` / `docker buildx imagetools inspect`.
+          provenance: mode=max
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless, GitHub OIDC)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Sign the digest once; all tags reference the same manifest.
+          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
+      - name: Scan pushed image (Trivy)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -7,7 +7,11 @@
 #           posthorn:local
 
 # --- Stage 1: build the static binary ----------------------------------
-FROM golang:1.25-alpine AS builder
+# Base images pinned by manifest-list digest (#39) so a tag repoint
+# upstream can't silently change what we build from. Dependabot keeps
+# the digests fresh (.github/dependabot.yml); the tag comment is for
+# humans.
+FROM golang:1.25-alpine@sha256:523c3effe300580ed375e43f43b1c9b091b68e935a7c3a92bfcc4e7ed55b18c2 AS builder
 
 ARG VERSION=dev
 ARG TARGETOS=linux
@@ -39,7 +43,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
         ./cmd/posthorn
 
 # --- Stage 2: minimal runtime ------------------------------------------
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 LABEL org.opencontainers.image.title="Posthorn" \
       org.opencontainers.image.description="The unified outbound mail layer for self-hosted projects" \

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -42,17 +42,17 @@ type SMTPListenerConfig struct {
 	// plaintext, only sensible for local development).
 	RequireTLS *bool `toml:"require_tls"`
 
-	TLSCert                 string              `toml:"tls_cert"`
-	TLSKey                  string              `toml:"tls_key"`
-	ClientCertCA            string              `toml:"client_cert_ca"`
-	AuthRequired            string              `toml:"auth_required"`
-	SMTPUsers               []SMTPUser          `toml:"smtp_users"`
-	AllowedSenders          []string            `toml:"allowed_senders"`
-	AllowedRecipients       []string            `toml:"allowed_recipients"`
-	MaxRecipientsPerSession int                 `toml:"max_recipients_per_session"`
-	MaxMessageSize          string              `toml:"max_message_size"`
-	IdleTimeout             Duration            `toml:"idle_timeout"`
-	Transport               TransportConfig     `toml:"transport"`
+	TLSCert                 string          `toml:"tls_cert"`
+	TLSKey                  string          `toml:"tls_key"`
+	ClientCertCA            string          `toml:"client_cert_ca"`
+	AuthRequired            string          `toml:"auth_required"`
+	SMTPUsers               []SMTPUser      `toml:"smtp_users"`
+	AllowedSenders          []string        `toml:"allowed_senders"`
+	AllowedRecipients       []string        `toml:"allowed_recipients"`
+	MaxRecipientsPerSession int             `toml:"max_recipients_per_session"`
+	MaxMessageSize          string          `toml:"max_message_size"`
+	IdleTimeout             Duration        `toml:"idle_timeout"`
+	Transport               TransportConfig `toml:"transport"`
 }
 
 // SMTPUser is a single AUTH PLAIN credential pair.

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -297,12 +297,9 @@ func TestValidate_PostmarkAPIKeyRequired(t *testing.T) {
 // --- Validation: NFR4 — allowed_origins explicitly empty ---
 
 func TestValidate_AllowedOriginsExplicitlyEmpty(t *testing.T) {
-	bad := minimalTOML + `allowed_origins = []
-`
-	// The append above adds at the end of the previous endpoint table — we
-	// need to inject inside the endpoint block before the [endpoints.transport]
-	// sub-table. Rebuild manually for clarity.
-	bad = `
+	// allowed_origins must be injected inside the endpoint block before
+	// the [endpoints.transport] sub-table, so build the TOML manually.
+	bad := `
 [[endpoints]]
 path = "/api/contact"
 to = ["craig@example.com"]
@@ -445,7 +442,7 @@ func TestLoad_EnvVarMissing(t *testing.T) {
 	// Make sure the var is unset for this test even if the test environment
 	// has it set globally.
 	t.Setenv("DEFINITELY_UNSET_FOR_THIS_TEST", "x")
-	os.Unsetenv("DEFINITELY_UNSET_FOR_THIS_TEST")
+	_ = os.Unsetenv("DEFINITELY_UNSET_FOR_THIS_TEST")
 
 	c := strings.Replace(minimalTOML, `api_key = "test-key"`, `api_key = "${env.DEFINITELY_UNSET_FOR_THIS_TEST}"`, 1)
 	_, err := loadString(t, c)
@@ -460,8 +457,8 @@ func TestLoad_EnvVarMissing(t *testing.T) {
 func TestLoad_EnvVarMissing_AllReportedTogether(t *testing.T) {
 	// Operators benefit from seeing all unset vars at once rather than
 	// re-running on each fix. Verify the loader collects them.
-	os.Unsetenv("MISSING_A")
-	os.Unsetenv("MISSING_B")
+	_ = os.Unsetenv("MISSING_A")
+	_ = os.Unsetenv("MISSING_B")
 
 	c := `
 [[endpoints]]

--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -76,9 +76,9 @@ type Handler struct {
 	authFailLimiter      *ratelimit.Limiter // nil on form-mode endpoints; per-IP brute-force defense for api-mode 401s
 	idemCache            *idempotency.Cache // nil on form-mode endpoints
 	trustedProxies       []netip.Prefix
-	emailField           string // resolved at construction (cfg.EmailField or default)
-	maxBodySize          int64  // 0 = no cap
-	logFailedSubmissions bool   // resolved at construction (default true)
+	emailField           string        // resolved at construction (cfg.EmailField or default)
+	maxBodySize          int64         // 0 = no cap
+	logFailedSubmissions bool          // resolved at construction (default true)
 	csrfTokenTTL         time.Duration // resolved at construction (cfg.CSRFTokenTTL or default)
 	logger               *slog.Logger
 	recorder             *metrics.Recorder // nil = no-op (default)
@@ -255,6 +255,7 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 //  7. Honeypot check   → silent 200 if filled → 200 (silent)
 //  8. Required fields  → all required present and non-empty → 422
 //  9. Email format     → submitter email well-formed → 422
+//
 // 10. Render subject/body, transport.Send (with retries) → 200 or 502
 //
 // Submission lifecycle is logged at every decision point with a

--- a/core/gateway/handler_test.go
+++ b/core/gateway/handler_test.go
@@ -896,8 +896,8 @@ func TestHandler_RateLimit_DifferentIPsIndependent(t *testing.T) {
 
 // scriptedTransport returns a sequence of pre-set errors.
 type scriptedTransport struct {
-	calls    int
-	results  []error // index = call number (0-based); past end = nil
+	calls   int
+	results []error // index = call number (0-based); past end = nil
 }
 
 func (s *scriptedTransport) Send(_ context.Context, _ transport.Message) (transport.SendResult, error) {

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -182,7 +182,7 @@ func TestRegistry_EmitsAllSortedByName(t *testing.T) {
 	if aaa < 0 || mmm < 0 || zzz < 0 {
 		t.Fatalf("metric missing from output: %s", out)
 	}
-	if !(aaa < mmm && mmm < zzz) {
+	if aaa >= mmm || mmm >= zzz {
 		t.Errorf("metrics not in sorted order: aaa=%d mmm=%d zzz=%d", aaa, mmm, zzz)
 	}
 }

--- a/core/metrics/recorder.go
+++ b/core/metrics/recorder.go
@@ -18,15 +18,15 @@ var LatencyBuckets = []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10}
 // without an enabling-condition check; tests that don't care about
 // metrics pass nil.
 type Recorder struct {
-	submitted      *Counter
-	sent           *Counter
-	failed         *Counter
-	rateLimited    *Counter
-	authFailed     *Counter
-	spamBlocked    *Counter
+	submitted        *Counter
+	sent             *Counter
+	failed           *Counter
+	rateLimited      *Counter
+	authFailed       *Counter
+	spamBlocked      *Counter
 	validationFailed *Counter
 	idempotentReplay *Counter
-	sendLatency    *Histogram
+	sendLatency      *Histogram
 }
 
 // NewRecorder constructs a Recorder backed by counters and histograms

--- a/core/response/response.go
+++ b/core/response/response.go
@@ -43,8 +43,8 @@ type Success struct {
 // passed to transport.Send so operators can debug template rendering
 // and recipient resolution without sending mail.
 type DryRun struct {
-	Status          string         `json:"status"`
-	SubmissionID    string         `json:"submission_id"`
+	Status          string          `json:"status"`
+	SubmissionID    string          `json:"submission_id"`
 	PreparedMessage PreparedMessage `json:"prepared_message"`
 }
 

--- a/core/smtp/listener_test.go
+++ b/core/smtp/listener_test.go
@@ -424,7 +424,7 @@ func TestSMTP_MessageSizeCap_552(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	tp := textproto.NewConn(conn)
 	_, _, _ = tp.ReadResponse(220)
 
@@ -578,7 +578,7 @@ func expectMultiline(t *testing.T, tp *textproto.Conn, wantCode int) {
 			t.Fatalf("malformed reply: %q", line)
 		}
 		var code int
-		fmt.Sscanf(line[:3], "%d", &code)
+		_, _ = fmt.Sscanf(line[:3], "%d", &code)
 		if code != wantCode {
 			t.Fatalf("got code %d, want %d (line %q)", code, wantCode, line)
 		}

--- a/core/smtp/session.go
+++ b/core/smtp/session.go
@@ -33,16 +33,16 @@ import (
 // Invalid command sequences return 503 5.5.1 "Bad sequence of commands"
 // without leaving the current state.
 type session struct {
-	l       *Listener
-	conn    net.Conn
-	tp      *textproto.Conn
-	logger  *slog.Logger
-	id      string
+	l      *Listener
+	conn   net.Conn
+	tp     *textproto.Conn
+	logger *slog.Logger
+	id     string
 
 	// Negotiated state.
-	tlsActive       bool
-	authedUser      string // empty until auth completes
-	authedViaCert   bool
+	tlsActive     bool
+	authedUser    string // empty until auth completes
+	authedViaCert bool
 
 	// Per-transaction state. Resets on RSET, MAIL FROM, or after
 	// successful DATA.

--- a/core/spam/spam_test.go
+++ b/core/spam/spam_test.go
@@ -138,8 +138,8 @@ func TestOrigin_OriginWinsOverReferer(t *testing.T) {
 	// Origin is more specific; if it's set, use it. Don't try Referer
 	// as a fallback when Origin disagrees.
 	got, _ := spam.CheckOrigin(
-		"https://attacker.example",                // not allowed
-		"https://example.com/legit-looking-page",  // would match if used
+		"https://attacker.example",               // not allowed
+		"https://example.com/legit-looking-page", // would match if used
 		[]string{"https://example.com"},
 	)
 	// Origin wins. Although CheckOrigin tries Referer when Origin doesn't

--- a/core/template/template_test.go
+++ b/core/template/template_test.go
@@ -178,7 +178,7 @@ func TestRenderBody_ExtrasSorted(t *testing.T) {
 	if idxAlpha < 0 || idxMike < 0 || idxZeta < 0 {
 		t.Fatalf("missing keys in body: %q", got)
 	}
-	if !(idxAlpha < idxMike && idxMike < idxZeta) {
+	if idxAlpha >= idxMike || idxMike >= idxZeta {
 		t.Errorf("not sorted alphabetically: alpha@%d mike@%d zeta@%d", idxAlpha, idxMike, idxZeta)
 	}
 }

--- a/core/transport/mailgun.go
+++ b/core/transport/mailgun.go
@@ -141,7 +141,7 @@ func (m *MailgunTransport) Send(ctx context.Context, msg Message) (SendResult, e
 			Message: "mailgun request failed",
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, mailgunResponseSizeLimit))
 

--- a/core/transport/postmark.go
+++ b/core/transport/postmark.go
@@ -145,7 +145,7 @@ func (p *PostmarkTransport) Send(ctx context.Context, msg Message) (SendResult, 
 			Message: "postmark request failed",
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, postmarkResponseSizeLimit))
 

--- a/core/transport/resend.go
+++ b/core/transport/resend.go
@@ -133,7 +133,7 @@ func (r *ResendTransport) Send(ctx context.Context, msg Message) (SendResult, er
 			Message: "resend request failed",
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, resendResponseSizeLimit))
 

--- a/core/transport/ses.go
+++ b/core/transport/ses.go
@@ -25,10 +25,10 @@ import (
 // signature is opaque material, not user input.
 
 const (
-	sesServiceName        = "ses"
-	sesSendPath           = "/v2/email/outbound-emails"
-	sesRequestTimeout     = 5 * time.Second
-	sesResponseSizeLimit  = 64 * 1024
+	sesServiceName       = "ses"
+	sesSendPath          = "/v2/email/outbound-emails"
+	sesRequestTimeout    = 5 * time.Second
+	sesResponseSizeLimit = 64 * 1024
 )
 
 var sesHTTPClient = &http.Client{
@@ -159,7 +159,7 @@ func (s *SESTransport) Send(ctx context.Context, msg Message) (SendResult, error
 			Message: "ses request failed",
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, sesResponseSizeLimit))
 

--- a/core/transport/smtpout_test.go
+++ b/core/transport/smtpout_test.go
@@ -85,7 +85,7 @@ func (s *fakeSMTPServer) acceptLoop() {
 }
 
 func (s *fakeSMTPServer) handle(conn net.Conn) {
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	session := &fakeSession{}
 	s.mu.Lock()
 	s.Sessions = append(s.Sessions, session)
@@ -472,8 +472,8 @@ func TestSMTPOut_HeaderInjection(t *testing.T) {
 			Subject: "s", BodyText: "b",
 		}},
 		{"crlf_in_to_recipient", Message{
-			From: "f@example.com",
-			To:   []string{"r@example.com\r\nBcc: victim@target.com"},
+			From:    "f@example.com",
+			To:      []string{"r@example.com\r\nBcc: victim@target.com"},
 			Subject: "s", BodyText: "b",
 		}},
 	}

--- a/core/transport/transport_test.go
+++ b/core/transport/transport_test.go
@@ -169,7 +169,7 @@ func TestTransportError_Unwrap(t *testing.T) {
 		t.Error("errors.Is(err, cause) = false, want true")
 	}
 
-	var unwrapped error = err.Unwrap()
+	unwrapped := err.Unwrap()
 	if unwrapped != cause {
 		t.Errorf("Unwrap() = %v, want %v", unwrapped, cause)
 	}


### PR DESCRIPTION
## Summary

Closes #38, #39, #56 — the CI/supply-chain batch from the 2026-07-03 audit.

- **CI gates (#38):** gofmt gate + govulncheck in the test job, golangci-lint as a separate job. All three verified green locally against this branch (govulncheck: no vulnerabilities; golangci-lint 2.12.2: 0 issues).
- **One-time cleanup** so the gates land green: 14 pre-existing lint findings fixed using the codebase's own `_ =` idiom, plus gofmt alignment drift in 9 files. All mechanical; full test suite passes with `-race`.
- **Digest pins (#39):** both Dockerfile base images pinned by manifest-list digest, with Dependabot (new `.github/dependabot.yml`) keeping docker/gomod/actions fresh weekly.
- **Supply chain (#56):** provenance `mode=max` + SBOM re-enabled (the 2025-era "tools mishandle attestation manifests" concern no longer holds), cosign keyless signing of the pushed digest via GitHub OIDC (`id-token: write`), Trivy scan gating on CRITICAL/HIGH with `ignore-unfixed`.

## Merge-order note

**Merge this last** (after #49 → #64 → #65 → #66). The gofmt/lint cleanup touches files those PRs also touch; if conflicts appear, the resolution is mechanical: take their side, re-run `gofmt -w .` and `golangci-lint run` in `core/`, commit.

Note: Trivy scans the already-pushed image (multi-arch buildx can't be scanned pre-push without loading single-arch); a failed scan fails the release run loudly rather than blocking the push. Acceptable for a tag-driven flow — the tag can be deleted and re-cut.

## Test plan

- [x] YAML validity for all three files
- [x] `gofmt -l` clean, `golangci-lint run` 0 issues, `govulncheck` clean — locally on this branch
- [x] `go vet` + `go test -race -count=1 ./...` — all 14 packages pass
- [ ] Release workflow changes exercise on the next tag (cosign/Trivy can't run locally)

Closes #38. Closes #39. Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)