### PR TITLE
refactor(gateway): extract the two-phase spam-check pipeline (#60)

### DIFF
--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -72,7 +72,21 @@ type Handler struct {
 	csrfTokenTTL         time.Duration // resolved at construction (cfg.CSRFTokenTTL or default)
 	logger               *slog.Logger
 	recorder             *metrics.Recorder // nil = no-op (default)
+
+	// Spam-check pipeline, built once from config (form mode only). Header
+	// checks run pre-parse/pre-rate-limit (origin, ...); form checks run
+	// post-parse (honeypot, csrf, ...). Each returns a spam.Verdict the
+	// handler renders through one mapping (applySpamVerdict), so adding a
+	// check is a new builder entry, not another inline block in ServeHTTP.
+	headerChecks []headerCheck
+	formChecks   []formCheck
 }
+
+// headerCheck inspects the request before the body is parsed (headers, IP).
+type headerCheck func(*http.Request) spam.Verdict
+
+// formCheck inspects the parsed form after the body is read.
+type formCheck func(url.Values) spam.Verdict
 
 // defaultAuthFailureBudget caps brute-force attempts against api-mode
 // endpoints. Token bucket per client IP: defaultAuthFailureBudget tokens
@@ -225,11 +239,96 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		logFailedSubmissions: logFailed,
 		csrfTokenTTL:         csrfTTL,
 		logger:               log.Discard(), // overridable via WithLogger
+		headerChecks:         buildHeaderChecks(cfg),
+		formChecks:           buildFormChecks(cfg, csrfTTL),
 	}
 	for _, opt := range opts {
 		opt(h)
 	}
 	return h, nil
+}
+
+// buildHeaderChecks assembles the pre-parse spam checks from config. Each
+// entry closes over its config so ServeHTTP just iterates. Form-mode
+// fields (allowed_origins) are empty on api-mode endpoints (rejected at
+// parse per ADR-10), so this returns nil there.
+func buildHeaderChecks(cfg config.EndpointConfig) []headerCheck {
+	var checks []headerCheck
+	if len(cfg.AllowedOrigins) > 0 {
+		allowed := cfg.AllowedOrigins
+		checks = append(checks, func(r *http.Request) spam.Verdict {
+			origin, referer := spam.ExtractOriginAndReferer(r)
+			if result, reason := spam.CheckOrigin(origin, referer, allowed); result == spam.HardReject {
+				v := spam.Blocks("origin")
+				v.Reason = reason
+				return v
+			}
+			return spam.Verdict{}
+		})
+	}
+	return checks
+}
+
+// buildFormChecks assembles the post-parse spam checks from config.
+func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration) []formCheck {
+	var checks []formCheck
+	if cfg.Honeypot != "" {
+		field := cfg.Honeypot
+		checks = append(checks, func(form url.Values) spam.Verdict {
+			if spam.CheckHoneypot(form, field) == spam.SilentReject {
+				// Silent 200 so a bot can't tell rejection from success.
+				return spam.Verdict{Blocked: true, Silent: true, Kind: "honeypot"}
+			}
+			return spam.Verdict{}
+		})
+	}
+	if cfg.CSRFSecret != "" {
+		secret := []byte(cfg.CSRFSecret)
+		checks = append(checks, func(form url.Values) spam.Verdict {
+			token := form.Get(csrf.TokenField)
+			if err := csrf.Verify(token, secret, csrfTTL, time.Now()); err != nil {
+				return spam.Verdict{Blocked: true, Kind: "csrf", Event: "csrf_rejected", Reason: err.Error()}
+			}
+			return spam.Verdict{}
+		})
+	}
+	return checks
+}
+
+// applySpamVerdict renders a blocking Verdict as the log line, metric, and
+// HTTP response, and reports whether it handled the request. A passing
+// verdict returns false so ServeHTTP continues. This is the single mapping
+// every spam check flows through.
+func (h *Handler) applySpamVerdict(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v spam.Verdict, clientIP, submissionID string, start time.Time) bool {
+	if !v.Blocked {
+		return false
+	}
+	event := v.Event
+	if event == "" {
+		event = "spam_blocked"
+	}
+	attrs := []any{slog.String("kind", v.Kind)}
+	if v.Reason != "" {
+		attrs = append(attrs, slog.String("reason", v.Reason))
+	}
+	attrs = append(attrs, slog.Int64("latency_ms", time.Since(start).Milliseconds()))
+	if !h.cfg.StripClientIP && clientIP != "" {
+		// Operator forensics parity with rate_limited (FR59 opt-out).
+		attrs = append(attrs, slog.String("client_ip", clientIP))
+	}
+	logger.Info(event, attrs...)
+	h.recorder.SpamBlocked(h.cfg.Path, v.Kind)
+
+	if v.Silent {
+		h.writeSuccessResponse(w, r, response.Success{Status: "ok", SubmissionID: submissionID})
+	} else {
+		status := v.Status
+		if status == 0 {
+			status = http.StatusForbidden
+		}
+		h.writeErrorResponse(w, r, status, "forbidden")
+	}
+	return true
 }
 
 // ServeHTTP implements [net/http.Handler].
@@ -358,29 +457,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Origin/Referer check (FR6, NFR4). Form-mode only; API mode is
-		// authenticated so browser CORS defenses do not apply.
-		if len(h.cfg.AllowedOrigins) > 0 {
-			origin, referer := spam.ExtractOriginAndReferer(r)
-			if result, reason := spam.CheckOrigin(origin, referer, h.cfg.AllowedOrigins); result == spam.HardReject {
-				attrs := []any{
-					slog.String("kind", "origin"),
-					slog.String("reason", reason),
-					slog.Int64("latency_ms", time.Since(start).Milliseconds()),
-				}
-				if !h.cfg.StripClientIP {
-					// Operator forensics parity with rate_limited —
-					// unless strip_client_ip is set (FR59 GDPR option).
-					attrs = append(attrs, slog.String("client_ip", ratelimit.ClientIP(r, h.trustedProxies)))
-				}
-				logger.Info("spam_blocked", attrs...)
-				h.recorder.SpamBlocked(h.cfg.Path, "origin")
-				h.writeErrorResponse(w, r, http.StatusForbidden, "forbidden")
+		// Resolve the client IP once: it keys the rate limiter (form mode)
+		// and is the forensics field on every spam-check log line.
+		rateLimitKey = ratelimit.ClientIP(r, h.trustedProxies)
+
+		// Header-phase spam checks (FR6, NFR4). Run before the rate limiter
+		// so a rejection doesn't consume a token. Origin/Referer today;
+		// the pipeline holds any future header/IP checks.
+		for _, check := range h.headerChecks {
+			if h.applySpamVerdict(w, r, logger, check(r), rateLimitKey, submissionID, start) {
 				return
 			}
 		}
-
-		rateLimitKey = ratelimit.ClientIP(r, h.trustedProxies)
 	}
 
 	// Rate limit check (FR8). Bucket key differs by mode (set above).
@@ -467,45 +555,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// for the same reason: an observant bot inspecting the body must
 	// not be able to tell the two paths apart. Form mode only — API
 	// mode is authenticated and has no browser bots.
-	if !apiMode && spam.CheckHoneypot(r.Form, h.cfg.Honeypot) == spam.SilentReject {
-		attrs := []any{
-			slog.String("kind", "honeypot"),
-			slog.Int64("latency_ms", time.Since(start).Milliseconds()),
-		}
-		if !h.cfg.StripClientIP {
-			// rateLimitKey is the client IP in form mode (set above);
-			// logged for operator forensics, parity with rate_limited.
-			attrs = append(attrs, slog.String("client_ip", rateLimitKey))
-		}
-		logger.Info("spam_blocked", attrs...)
-		h.recorder.SpamBlocked(h.cfg.Path, "honeypot")
-		h.writeSuccessResponse(w, r, response.Success{
-			Status:       "ok",
-			SubmissionID: submissionID,
-		})
-		return
-	}
-
-	// FR57: CSRF check (form-mode only). When csrf_secret is configured,
-	// every submission must carry a verifiable _csrf_token form field.
-	// Failures return 403 with no detail — the structured log line has
-	// the operator-facing reason.
-	if !apiMode && h.cfg.CSRFSecret != "" {
-		token := r.Form.Get(csrf.TokenField)
-		if err := csrf.Verify(token, []byte(h.cfg.CSRFSecret), h.csrfTokenTTL, time.Now()); err != nil {
-			attrs := []any{
-				slog.String("reason", err.Error()),
-				slog.Int64("latency_ms", time.Since(start).Milliseconds()),
+	// Form-phase spam checks (form mode only): honeypot (silent 200) and
+	// CSRF (403, logged as csrf_rejected), plus any future post-parse
+	// checks (content-shape, reputation, captcha). Each flows through the
+	// same verdict mapping.
+	if !apiMode {
+		for _, check := range h.formChecks {
+			if h.applySpamVerdict(w, r, logger, check(r.Form), rateLimitKey, submissionID, start) {
+				return
 			}
-			if !h.cfg.StripClientIP {
-				attrs = append(attrs, slog.String("client_ip", rateLimitKey))
-			}
-			logger.Info("csrf_rejected", attrs...)
-			// CSRF rejections count as spam blocks on /metrics — without
-			// this a CSRF-blocked flood is invisible to operators.
-			h.recorder.SpamBlocked(h.cfg.Path, "csrf")
-			h.writeErrorResponse(w, r, http.StatusForbidden, "forbidden")
-			return
 		}
 	}
 

--- a/core/gateway/handler_test.go
+++ b/core/gateway/handler_test.go
@@ -2441,6 +2441,47 @@ func csrfConfig(secret string) config.EndpointConfig {
 
 const csrfTestSecret = "0123456789abcdef0123456789abcdef" // 32 bytes
 
+// TestSpamPipeline_FormChecks_Order verifies the extracted pipeline runs
+// form checks in order and short-circuits on the first block: with both a
+// honeypot and CSRF configured, a filled honeypot returns the silent 200
+// before CSRF is ever evaluated (so a missing token doesn't turn it into a
+// 403). Locks in the one new behavior the pipeline introduces over the
+// former inline blocks.
+func TestSpamPipeline_FormChecks_Order(t *testing.T) {
+	cfg := config.EndpointConfig{
+		Path:       "/test",
+		To:         []string{"to@example.com"},
+		From:       "from@example.com",
+		Subject:    "S",
+		Body:       "B",
+		Honeypot:   "_gotcha",
+		CSRFSecret: csrfTestSecret,
+	}
+	rt := &recordingTransport{}
+	h, err := gateway.New(cfg, rt)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Honeypot filled AND no CSRF token. Honeypot runs first → silent 200,
+	// no mail, CSRF never reached.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest("message=hi&_gotcha=bot"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("honeypot-first: status = %d, want 200 (silent)", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("honeypot silent-reject still sent %d messages", len(rt.sent))
+	}
+
+	// Honeypot empty, CSRF token missing → CSRF blocks with 403.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest("message=hi"))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("csrf-missing: status = %d, want 403", rec.Code)
+	}
+}
+
 func TestCSRF_ValidToken_Succeeds(t *testing.T) {
 	rt := &recordingTransport{}
 	cfg := csrfConfig(csrfTestSecret)

--- a/core/spam/verdict.go
+++ b/core/spam/verdict.go
@@ -1,0 +1,39 @@
+package spam
+
+// Verdict is a spam check's decision plus everything the handler needs to
+// render the outcome: the response shape, the log line, and the metric
+// label. Collecting these into one value lets the gateway apply a single
+// mapping (log + metric + response) for every check instead of a bespoke
+// inline block per check — so adding a check is a new builder entry, not
+// another branch in ServeHTTP.
+//
+// The zero Verdict means "not blocked; continue the pipeline."
+type Verdict struct {
+	// Blocked is false for a passing check. When false, all other fields
+	// are ignored.
+	Blocked bool
+
+	// Silent selects the response when Blocked. true → accept-and-discard
+	// with a 200 in the success body shape (the honeypot behavior, so a
+	// bot can't distinguish rejection from success). false → reject with
+	// Status.
+	Silent bool
+
+	// Status is the HTTP status for a non-silent block. Zero means 403.
+	Status int
+
+	// Kind is the operator-facing check name — the metrics label and the
+	// log "kind" field. Never submitter content (NFR24). E.g. "origin",
+	// "honeypot", "csrf".
+	Kind string
+
+	// Event is the structured-log message. Empty means "spam_blocked".
+	// The CSRF check sets "csrf_rejected" to preserve its distinct event.
+	Event string
+
+	// Reason is optional log detail (the specific check that fired).
+	Reason string
+}
+
+// Blocks constructs a hard-reject Verdict (403 unless Status is set later).
+func Blocks(kind string) Verdict { return Verdict{Blocked: true, Kind: kind} }

--- a/site/src/content/docs/reference/log-format.mdx
+++ b/site/src/content/docs/reference/log-format.mdx
@@ -195,6 +195,7 @@ Form-mode only, when `csrf_secret` is configured. The `_csrf_token` form field w
   "submission_id": "...",
   "endpoint": "/api/contact",
   "transport": "postmark",
+  "kind": "csrf",
   "reason": "csrf: token expired",
   "client_ip": "203.0.113.7",
   "latency_ms": 1


### PR DESCRIPTION
Pre-work for the Spam protection milestone. Pure refactor, no behavior change.

## The problem

Origin, honeypot, and CSRF were three inline blocks in `ServeHTTP`, each hand-rolling the same log + `client_ip` + metric + response boilerplate. The milestone adds six more checks (#34/#44/#45/#33/#32/#31) — as inline blocks, that's six more copies onto an already-375-line handler.

## The shape

- `spam.Verdict` carries a check's decision plus everything the handler needs to render it (silent-200 vs reject, log event, metric kind, reason).
- The gateway builds `[]headerCheck` (pre-parse) and `[]formCheck` (post-parse) from config once in `New()`.
- `ServeHTTP` iterates each phase and applies one `applySpamVerdict` mapping. Adding a check is now a builder entry, not another branch.

The two-phase split is preserved on purpose: header checks run before the rate limiter (so a reject doesn't spend a token), form checks after parse.

## Faithfulness

The whole existing origin / honeypot / csrf / client_ip / metric suite passes unchanged — that's the proof the extraction is behavior-preserving. Two small deltas, both improvements:
- Client IP is resolved once, not recomputed for the origin-reject log (the efficiency finding from the earlier review).
- `csrf_rejected` log lines now also carry `kind="csrf"`, matching the other spam-block events (additive; log-format doc updated).

New test `TestSpamPipeline_FormChecks_Order` locks in the one genuinely new behavior: form checks short-circuit in order, so a filled honeypot returns its silent 200 before CSRF is evaluated.

## Verified

gofmt clean, golangci-lint 0 issues, 15 packages green with `-race`.

Unblocks the check work: #34 → #44 → #45 → #33 → #32 → #31, plus #61/#62/#63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)