### PR TITLE
feat(spam): proof-of-browser challenge token (#45, ADR-18)

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -147,6 +147,32 @@ type EndpointConfig struct {
 	// (form-mode only). Content-agnostic — targets repeat form-spam
 	// identities. See ReputationConfig.
 	Reputation *ReputationConfig `toml:"reputation"`
+
+	// ProofOfBrowser: optional JS-gated submit token (form-mode only,
+	// #45/ADR-18). Blocks bots that POST directly without executing the
+	// page JavaScript that fetches the token. See ProofOfBrowserConfig.
+	ProofOfBrowser *ProofOfBrowserConfig `toml:"proof_of_browser"`
+}
+
+// ProofOfBrowserConfig configures the proof-of-browser check
+// (`[endpoints.proof_of_browser]`). Its presence enables the check.
+// Posthorn serves a challenge token from a GET on the endpoint; the
+// operator embeds a small script that fetches it and injects it as the
+// `_pob_token` field before submit. Form-mode only (ADR-18).
+type ProofOfBrowserConfig struct {
+	// Secret is the HMAC key for the challenge token. Optional: when
+	// empty, Posthorn generates a random one at startup (fine for a
+	// single replica). Set it explicitly for multi-replica deployments so
+	// every replica verifies the same tokens; ≥16 bytes when set.
+	Secret string `toml:"secret"`
+
+	// TTL is the token lifetime. Default 30m.
+	TTL Duration `toml:"ttl"`
+
+	// MinAge, when set, rejects a token submitted sooner than this after
+	// it was issued — a time-trap for bots that fetch-then-submit
+	// instantly. Must be less than the effective TTL.
+	MinAge Duration `toml:"min_age"`
 }
 
 // ReputationConfig configures the optional reputation check
@@ -206,6 +232,31 @@ func (r *ReputationConfig) validate() error {
 	}
 	if r.CacheTTL.Std() < 0 {
 		return fmt.Errorf("cache_ttl: must be non-negative, got %v", r.CacheTTL.Std())
+	}
+	return nil
+}
+
+// validate checks the proof_of_browser block. Called only for form-mode
+// endpoints (api-mode rejects the whole block above).
+func (p *ProofOfBrowserConfig) validate() error {
+	if p.Secret != "" {
+		if err := csrf.ValidateSecret([]byte(p.Secret)); err != nil {
+			return err
+		}
+	}
+	if p.TTL.Std() < 0 {
+		return fmt.Errorf("ttl: must be non-negative, got %v", p.TTL.Std())
+	}
+	if p.MinAge.Std() < 0 {
+		return fmt.Errorf("min_age: must be non-negative, got %v", p.MinAge.Std())
+	}
+	// Resolve the effective TTL for the min_age < ttl check (default 30m).
+	ttl := p.TTL.Std()
+	if ttl == 0 {
+		ttl = 30 * time.Minute
+	}
+	if p.MinAge.Std() >= ttl {
+		return fmt.Errorf("min_age (%v) must be less than ttl (%v)", p.MinAge.Std(), ttl)
 	}
 	return nil
 }
@@ -518,6 +569,9 @@ func (e *EndpointConfig) Validate() error {
 		if e.Reputation != nil {
 			return errors.New("reputation: not valid on auth=\"api-key\" endpoints (form-mode only in v1.1)")
 		}
+		if e.ProofOfBrowser != nil {
+			return errors.New("proof_of_browser: not valid on auth=\"api-key\" endpoints (server-to-server callers don't run a browser)")
+		}
 		// FR42: idempotency_cache_size must be positive when set; zero
 		// means "use the default" (handler-side resolution).
 		if e.IdempotencyCacheSize < 0 {
@@ -547,6 +601,11 @@ func (e *EndpointConfig) Validate() error {
 		if e.Reputation != nil {
 			if err := e.Reputation.validate(); err != nil {
 				return fmt.Errorf("reputation: %w", err)
+			}
+		}
+		if e.ProofOfBrowser != nil {
+			if err := e.ProofOfBrowser.validate(); err != nil {
+				return fmt.Errorf("proof_of_browser: %w", err)
 			}
 		}
 	}

--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -10,6 +10,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -82,6 +83,11 @@ type Handler struct {
 	// check is a new builder entry, not another inline block in ServeHTTP.
 	headerChecks []headerCheck
 	formChecks   []formCheck
+
+	// pob serves the proof-of-browser challenge (a GET on the endpoint);
+	// nil unless [endpoints.proof_of_browser] is configured. The matching
+	// verify check lives in formChecks.
+	pob *pobGate
 }
 
 // headerCheck inspects the request before the body is parsed (headers, IP).
@@ -105,6 +111,68 @@ const (
 // defaultCSRFTokenTTL is the resolved value when cfg.CSRFTokenTTL is
 // zero (operator didn't set it). One hour matches FR57's stated default.
 const defaultCSRFTokenTTL = time.Hour
+
+// Proof-of-browser (#45, ADR-18): a JS-gated submit token. pobTokenField
+// is the hidden form field the operator's inline script populates from
+// the challenge endpoint. defaultPOBTokenTTL matches the issue's default.
+const (
+	pobTokenField      = "_pob_token"
+	defaultPOBTokenTTL = 30 * time.Minute
+)
+
+// errPOBTooNew is the min-age (time-trap) rejection.
+var errPOBTooNew = errors.New("proof-of-browser token submitted too soon after issuance")
+
+// pobGate issues and verifies proof-of-browser tokens. It reuses the
+// CSRF HMAC-timestamp machinery (ADR-18: same token format, different
+// issuer — Posthorn issues via the challenge endpoint rather than the
+// operator at render time) and adds an optional minimum-age floor.
+type pobGate struct {
+	secret []byte
+	ttl    time.Duration
+	minAge time.Duration
+}
+
+func (p *pobGate) issue(now time.Time) string { return csrf.Issue(p.secret, now) }
+
+func (p *pobGate) verify(token string, now time.Time) error {
+	if err := csrf.Verify(token, p.secret, p.ttl, now); err != nil {
+		return err
+	}
+	if p.minAge > 0 {
+		// Verify passed, so the token is "<unix>.<hmac>" with a valid
+		// timestamp; re-parse it for the age check.
+		tsStr := token[:strings.IndexByte(token, '.')]
+		unix, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil {
+			return err
+		}
+		if now.Sub(time.Unix(unix, 0)) < p.minAge {
+			return errPOBTooNew
+		}
+	}
+	return nil
+}
+
+// buildPOBGate constructs the proof-of-browser gate, generating a random
+// secret when the operator didn't set one (single-replica zero-config).
+func buildPOBGate(cfg *config.ProofOfBrowserConfig) (*pobGate, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	secret := []byte(cfg.Secret)
+	if len(secret) == 0 {
+		secret = make([]byte, 32)
+		if _, err := rand.Read(secret); err != nil {
+			return nil, fmt.Errorf("generate secret: %w", err)
+		}
+	}
+	ttl := cfg.TTL.Std()
+	if ttl == 0 {
+		ttl = defaultPOBTokenTTL
+	}
+	return &pobGate{secret: secret, ttl: ttl, minAge: cfg.MinAge.Std()}, nil
+}
 
 // Option configures a Handler at construction time.
 type Option func(*Handler)
@@ -161,6 +229,10 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 	if cfg.CSRFSecret != "" {
 		// FR57: the CSRF token field is structural, not template content.
 		reserved = append(reserved, csrf.TokenField)
+	}
+	if cfg.ProofOfBrowser != nil {
+		// The proof-of-browser token field is structural (#45).
+		reserved = append(reserved, pobTokenField)
 	}
 
 	renderer, err := template.NewRenderer(cfg.Subject, cfg.Body, reserved)
@@ -235,6 +307,11 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		return nil, fmt.Errorf("gateway: reputation: %w", err)
 	}
 
+	pob, err := buildPOBGate(cfg.ProofOfBrowser)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: proof_of_browser: %w", err)
+	}
+
 	h := &Handler{
 		cfg:                  cfg,
 		transport:            t,
@@ -249,7 +326,8 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		csrfTokenTTL:         csrfTTL,
 		logger:               log.Discard(), // overridable via WithLogger
 		headerChecks:         buildHeaderChecks(cfg),
-		formChecks:           buildFormChecks(cfg, csrfTTL, emailField, repChecker),
+		pob:                  pob,
+		formChecks:           buildFormChecks(cfg, csrfTTL, emailField, repChecker, pob),
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -305,7 +383,7 @@ func buildReputationChecker(cfg *config.ReputationConfig) (*reputation.Checker, 
 }
 
 // buildFormChecks assembles the post-parse spam checks from config.
-func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailField string, rep *reputation.Checker) []formCheck {
+func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailField string, rep *reputation.Checker, pob *pobGate) []formCheck {
 	var checks []formCheck
 	if cfg.Honeypot != "" {
 		field := cfg.Honeypot
@@ -323,6 +401,17 @@ func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailFiel
 			token := form.Get(csrf.TokenField)
 			if err := csrf.Verify(token, secret, csrfTTL, time.Now()); err != nil {
 				return spam.Verdict{Blocked: true, Kind: "csrf", Event: "csrf_rejected", Reason: err.Error()}
+			}
+			return spam.Verdict{}
+		})
+	}
+	if pob != nil {
+		// Proof-of-browser (#45): the submission must carry a valid
+		// challenge token, which only the page JavaScript can fetch.
+		// Cheap local HMAC check — runs before the network reputation call.
+		checks = append(checks, func(_ context.Context, form url.Values, _ string) spam.Verdict {
+			if err := pob.verify(form.Get(pobTokenField), time.Now()); err != nil {
+				return spam.Verdict{Blocked: true, Kind: "proof_of_browser", Event: "pob_rejected", Reason: err.Error()}
 			}
 			return spam.Verdict{}
 		})
@@ -345,6 +434,28 @@ func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailFiel
 		})
 	}
 	return checks
+}
+
+// serveChallenge answers a GET on a proof-of-browser endpoint with a
+// fresh token as JSON. When allowed_origins is configured, it enforces
+// the same origin allow-list so tokens can't be farmed from other sites;
+// it echoes an allowed Origin for CORS so a cross-origin form fetch can
+// read the token.
+func (h *Handler) serveChallenge(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin != "" && len(h.cfg.AllowedOrigins) > 0 {
+		if res, _ := spam.CheckOrigin(origin, "", h.cfg.AllowedOrigins); res == spam.HardReject {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
+	if origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Vary", "Origin")
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]string{"token": h.pob.issue(time.Now())})
 }
 
 // applySpamVerdict renders a blocking Verdict as the log line, metric, and
@@ -426,6 +537,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, h.maxBodySize)
 	}
 
+	// Proof-of-browser challenge: a GET on a PoB-enabled endpoint issues a
+	// fresh token for the page JavaScript to fetch and inject (#45,
+	// ADR-18). Every other non-POST method is still 405.
+	if r.Method == http.MethodGet && h.pob != nil {
+		h.serveChallenge(w, r)
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/core/gateway/handler_test.go
+++ b/core/gateway/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -2577,6 +2578,112 @@ func TestReputation_FailOpen_SendsAndMeters(t *testing.T) {
 	reg.Handler().ServeHTTP(scrape, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	if want := `posthorn_reputation_failed_open_total{endpoint="/contact"} 1`; !strings.Contains(scrape.Body.String(), want) {
 		t.Errorf("missing fail-open metric %q:\n%s", want, scrape.Body.String())
+	}
+}
+
+// --- Proof-of-browser (#45) ---
+
+func pobEndpoint(minAge time.Duration) config.EndpointConfig {
+	return config.EndpointConfig{
+		Path:     "/test",
+		To:       []string{"ops@example.com"},
+		From:     "noreply@example.com",
+		Subject:  "Contact",
+		Body:     "{{.message}}",
+		Required: []string{"message"},
+		ProofOfBrowser: &config.ProofOfBrowserConfig{
+			TTL:    config.Duration(time.Hour),
+			MinAge: config.Duration(minAge),
+		},
+	}
+}
+
+// fetchPOBToken performs the challenge GET and returns the issued token.
+func fetchPOBToken(t *testing.T, h *gateway.Handler) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/test", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("challenge status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("challenge body not JSON: %v", err)
+	}
+	if body.Token == "" {
+		t.Fatal("challenge returned an empty token")
+	}
+	return body.Token
+}
+
+func TestProofOfBrowser_ChallengeThenSubmit(t *testing.T) {
+	rt := &recordingTransport{}
+	h, err := gateway.New(pobEndpoint(0), rt)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	token := fetchPOBToken(t, h)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hello"}, "_pob_token": {token}}.Encode()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with a valid token; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(rt.sent) != 1 {
+		t.Errorf("valid submission sent %d messages, want 1", len(rt.sent))
+	}
+}
+
+func TestProofOfBrowser_MissingToken_Blocked(t *testing.T) {
+	rt := &recordingTransport{}
+	h, _ := gateway.New(pobEndpoint(0), rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}}.Encode()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("no token: status = %d, want 403", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("blocked submission still sent %d messages", len(rt.sent))
+	}
+}
+
+func TestProofOfBrowser_ForgedToken_Blocked(t *testing.T) {
+	rt := &recordingTransport{}
+	h, _ := gateway.New(pobEndpoint(0), rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "_pob_token": {"1700000000.deadbeef"}}.Encode()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("forged token: status = %d, want 403", rec.Code)
+	}
+}
+
+func TestProofOfBrowser_MinAge_TooSoon_Blocked(t *testing.T) {
+	// A 1h min-age with a token fetched and submitted immediately is the
+	// time-trap: age ~ 0 < min_age, so the instant POST is rejected.
+	rt := &recordingTransport{}
+	h, _ := gateway.New(pobEndpoint(time.Hour), rt)
+	token := fetchPOBToken(t, h)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "_pob_token": {token}}.Encode()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("instant submit under min_age: status = %d, want 403", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("time-trapped submission sent %d messages", len(rt.sent))
+	}
+}
+
+func TestProofOfBrowser_Challenge_EnforcesAllowedOrigins(t *testing.T) {
+	cfg := pobEndpoint(0)
+	cfg.AllowedOrigins = []string{"https://example.com"}
+	h, _ := gateway.New(cfg, &recordingTransport{})
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("challenge from disallowed origin: status = %d, want 403", rec.Code)
 	}
 }
 

--- a/site/src/content/docs/configuration/reference.mdx
+++ b/site/src/content/docs/configuration/reference.mdx
@@ -165,6 +165,38 @@ fail_open  = true
 
 **Privacy:** enabling this sends the submitter's email and IP to StopForumSpam. It's off by default and opt-in. Note it in your privacy policy if your jurisdiction requires it.
 
+### Proof of browser (form-mode only)
+
+An optional `[endpoints.proof_of_browser]` block requires a token that only JavaScript can obtain, which blocks bots that POST the form directly without executing the page's script. It's content-agnostic and needs no third party. API-mode endpoints reject the block at parse time.
+
+```toml
+[endpoints.proof_of_browser]
+ttl     = "30m"
+min_age = "3s"   # optional time-trap: reject submissions faster than a human
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `secret` | string | no | random per start | HMAC key for the token. Leave unset for a single instance (a fresh random key is generated at startup). Set it (≥16 bytes) for multi-replica deployments so every replica verifies the same tokens. |
+| `ttl` | duration | no | `"30m"` | Token lifetime. |
+| `min_age` | duration | no | unset | When set, a token submitted sooner than this after issuance is rejected — a time-trap for bots that fetch-then-submit instantly. Must be less than `ttl`. |
+
+**How it works.** When enabled, a `GET` to the endpoint returns `{"token": "..."}`. Your form page fetches it and puts it in a hidden `_pob_token` field; Posthorn verifies it on submit. A missing, forged, expired, or too-new token is rejected with **403**. Add this to the page with your form (fetch on load so the token ages while the visitor types, which pairs with `min_age`):
+
+```html
+<form id="contact" action="https://posthorn.example.com/contact" method="POST">
+  <!-- your fields -->
+  <input type="hidden" name="_pob_token" value="">
+</form>
+<script>
+  fetch("https://posthorn.example.com/contact")
+    .then(r => r.json())
+    .then(d => { document.querySelector("#contact [name=_pob_token]").value = d.token; });
+</script>
+```
+
+If Posthorn is on a different host than the page, the challenge honors the endpoint's `allowed_origins` and sends the CORS header so the cross-origin `fetch` can read the token. Visitors with JavaScript disabled can't submit a proof-of-browser form, so keep it for public forms that get real bot traffic.
+
 ### Dry run
 
 | Field | Type | Required | Default | Description |


### PR DESCRIPTION
The second front-of-milestone check, stacked on #44. Catches the bots reputation hasn't catalogued yet: the distributed form-blasters that POST directly without running the page's JavaScript.

## How it works (ADR-18)

Posthorn issues the token, not the operator at render time, so it works on static sites too:

1. A `GET` on a proof-of-browser endpoint returns `{"token": "..."}` (an HMAC-timestamp token, reusing the CSRF crypto).
2. The operator drops a small inline script on the form page that fetches the token and injects a hidden `_pob_token` field.
3. The pipeline verifies it on submit. Missing, forged, expired, or (with `min_age`) too-new → **403**.

A `min_age` time-trap rejects tokens submitted faster than a human could fill the form, which catches the fetch-then-submit-instantly bots.

## What's here

- Config: `[endpoints.proof_of_browser]` (`secret` optional and auto-generated for single-replica, `ttl`, `min_age`), validated, form-mode only.
- Challenge endpoint on `GET`, enforcing `allowed_origins` and echoing an allowed Origin for cross-origin fetch.
- Wired through the #60 pipeline as a form check, before the network reputation call (cheap local HMAC first).
- Docs: config reference + the copy-paste embed snippet.

## Tests

Challenge→submit round trip, missing token, forged token, `min_age` time-trap, and origin enforcement on the challenge. gofmt/lint clean, 16 packages green with `-race`.

## Stacking

Based on `feat/44-reputation` (#81) since both are checks on the shared pipeline. GitHub retargets to main when #44 merges. Merge #44 first.

Next: #33 Turnstile (the backstop for JS-capable bots), and #32 CSRF min-age (which reuses the same time-trap primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)