### PR TITLE
feat(spam): Cloudflare Turnstile captcha check (#33)

### DIFF
--- a/core/captcha/captcha.go
+++ b/core/captcha/captcha.go
@@ -1,0 +1,100 @@
+// Package captcha verifies a Cloudflare Turnstile response token — the
+// escalation tier of the spam ladder (#33). Reputation (#44) and
+// proof-of-browser (#45) stop bots that reuse identities or don't run
+// JavaScript; Turnstile is the backstop for the ones that do render the
+// page and execute a real browser. It's opt-in per endpoint because it
+// adds a third-party dependency and a visible widget.
+package captcha
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// defaultBaseURL is Cloudflare Turnstile's siteverify endpoint.
+const defaultBaseURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+// ErrFailed means the provider verified the token and rejected it (a
+// bad, missing, or already-used response). Distinct from a transport or
+// provider error, which the caller handles per its fail-open policy.
+var ErrFailed = errors.New("captcha: token rejected by provider")
+
+// Config configures a Verifier.
+type Config struct {
+	BaseURL string // "" → Cloudflare's public siteverify
+	Secret  string // Turnstile secret key
+	Timeout time.Duration
+}
+
+// Verifier verifies Turnstile tokens against the provider.
+type Verifier struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// New builds a Verifier.
+func New(cfg Config) (*Verifier, error) {
+	if cfg.Secret == "" {
+		return nil, errors.New("captcha: secret is required")
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = defaultBaseURL
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	return &Verifier{baseURL: base, secret: cfg.Secret, http: &http.Client{Timeout: timeout}}, nil
+}
+
+type siteverifyResponse struct {
+	Success bool `json:"success"`
+}
+
+// Verify submits the response token to the provider. Returns nil when
+// the provider accepts it, ErrFailed when the provider rejects it, or a
+// wrapped transport/provider error otherwise (the caller decides whether
+// to fail open or closed).
+func (v *Verifier) Verify(ctx context.Context, token, remoteIP string) error {
+	if strings.TrimSpace(token) == "" {
+		// No token at all is a definite failure, not a provider error —
+		// no point spending a network round-trip on it.
+		return ErrFailed
+	}
+	form := url.Values{"secret": {v.secret}, "response": {token}}
+	if remoteIP != "" {
+		form.Set("remoteip", remoteIP)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.baseURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("captcha: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := v.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("captcha: provider request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("captcha: provider status %d", resp.StatusCode)
+	}
+
+	var sv siteverifyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sv); err != nil {
+		return fmt.Errorf("captcha: decode response: %w", err)
+	}
+	if !sv.Success {
+		return ErrFailed
+	}
+	return nil
+}

--- a/core/captcha/captcha_test.go
+++ b/core/captcha/captcha_test.go
@@ -1,0 +1,70 @@
+package captcha
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func fakeTurnstile(t *testing.T, success bool) *httptest.Server {
+	t.Helper()
+	body := `{"success":false,"error-codes":["invalid-input-response"]}`
+	if success {
+		body = `{"success":true}`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestVerify_Success(t *testing.T) {
+	srv := fakeTurnstile(t, true)
+	v, _ := New(Config{BaseURL: srv.URL, Secret: "s"})
+	if err := v.Verify(context.Background(), "good-token", "203.0.113.1"); err != nil {
+		t.Errorf("want nil for accepted token, got %v", err)
+	}
+}
+
+func TestVerify_Rejected(t *testing.T) {
+	srv := fakeTurnstile(t, false)
+	v, _ := New(Config{BaseURL: srv.URL, Secret: "s"})
+	if err := v.Verify(context.Background(), "bad-token", ""); !errors.Is(err, ErrFailed) {
+		t.Errorf("want ErrFailed for rejected token, got %v", err)
+	}
+}
+
+func TestVerify_EmptyToken_FailsWithoutNetwork(t *testing.T) {
+	// A closed server proves no request is made for an empty token.
+	srv := fakeTurnstile(t, true)
+	base := srv.URL
+	srv.Close()
+	v, _ := New(Config{BaseURL: base, Secret: "s", Timeout: 200 * time.Millisecond})
+	if err := v.Verify(context.Background(), "  ", ""); !errors.Is(err, ErrFailed) {
+		t.Errorf("empty token should be ErrFailed without a round-trip, got %v", err)
+	}
+}
+
+func TestVerify_ProviderError(t *testing.T) {
+	srv := fakeTurnstile(t, true)
+	base := srv.URL
+	srv.Close() // requests now fail
+	v, _ := New(Config{BaseURL: base, Secret: "s", Timeout: 200 * time.Millisecond})
+	err := v.Verify(context.Background(), "token", "")
+	if err == nil || errors.Is(err, ErrFailed) {
+		t.Errorf("provider error should be a non-ErrFailed error, got %v", err)
+	}
+}
+
+func TestNew_RequiresSecret(t *testing.T) {
+	if _, err := New(Config{}); err == nil {
+		t.Error("New should require a secret")
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -152,6 +152,34 @@ type EndpointConfig struct {
 	// #45/ADR-18). Blocks bots that POST directly without executing the
 	// page JavaScript that fetches the token. See ProofOfBrowserConfig.
 	ProofOfBrowser *ProofOfBrowserConfig `toml:"proof_of_browser"`
+
+	// Captcha: optional Cloudflare Turnstile verification (form-mode only,
+	// #33). The escalation tier — stops bots that render JS. See
+	// CaptchaConfig.
+	Captcha *CaptchaConfig `toml:"captcha"`
+}
+
+// CaptchaConfig configures the optional captcha check
+// (`[endpoints.captcha]`). Form-mode only.
+type CaptchaConfig struct {
+	// Provider is the captcha service. Only "turnstile" in this release.
+	Provider string `toml:"provider"`
+
+	// SecretKey is the provider secret used for server-side verification.
+	// Never sent to the client.
+	SecretKey string `toml:"secret_key"`
+
+	// OnProviderError selects behavior when the provider can't be reached:
+	// "closed" (default) rejects the submission; "open" allows it. A
+	// captcha that fails open is weak, so closed is the default; fail-open
+	// events increment posthorn_check_failed_open_total{check="captcha"}.
+	OnProviderError string `toml:"on_provider_error"`
+
+	// Timeout per verification. Default 3s.
+	Timeout Duration `toml:"timeout"`
+
+	// BaseURL overrides the siteverify endpoint (testing / self-hosted).
+	BaseURL string `toml:"base_url"`
 }
 
 // ProofOfBrowserConfig configures the proof-of-browser check
@@ -257,6 +285,26 @@ func (p *ProofOfBrowserConfig) validate() error {
 	}
 	if p.MinAge.Std() >= ttl {
 		return fmt.Errorf("min_age (%v) must be less than ttl (%v)", p.MinAge.Std(), ttl)
+	}
+	return nil
+}
+
+// validate checks the captcha block. Called only for form-mode endpoints.
+func (c *CaptchaConfig) validate() error {
+	if c.Provider != "turnstile" {
+		return fmt.Errorf("provider: only \"turnstile\" is supported, got %q", c.Provider)
+	}
+	if c.SecretKey == "" {
+		return errors.New("secret_key: required")
+	}
+	switch c.OnProviderError {
+	case "", "closed", "open":
+		// ok; empty means closed
+	default:
+		return fmt.Errorf("on_provider_error: must be \"closed\" or \"open\", got %q", c.OnProviderError)
+	}
+	if c.Timeout.Std() < 0 {
+		return fmt.Errorf("timeout: must be non-negative, got %v", c.Timeout.Std())
 	}
 	return nil
 }
@@ -572,6 +620,9 @@ func (e *EndpointConfig) Validate() error {
 		if e.ProofOfBrowser != nil {
 			return errors.New("proof_of_browser: not valid on auth=\"api-key\" endpoints (server-to-server callers don't run a browser)")
 		}
+		if e.Captcha != nil {
+			return errors.New("captcha: not valid on auth=\"api-key\" endpoints (server-to-server callers don't solve captchas)")
+		}
 		// FR42: idempotency_cache_size must be positive when set; zero
 		// means "use the default" (handler-side resolution).
 		if e.IdempotencyCacheSize < 0 {
@@ -606,6 +657,11 @@ func (e *EndpointConfig) Validate() error {
 		if e.ProofOfBrowser != nil {
 			if err := e.ProofOfBrowser.validate(); err != nil {
 				return fmt.Errorf("proof_of_browser: %w", err)
+			}
+		}
+		if e.Captcha != nil {
+			if err := e.Captcha.validate(); err != nil {
+				return fmt.Errorf("captcha: %w", err)
 			}
 		}
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -147,6 +147,32 @@ type EndpointConfig struct {
 	// (form-mode only). Content-agnostic — targets repeat form-spam
 	// identities. See ReputationConfig.
 	Reputation *ReputationConfig `toml:"reputation"`
+
+	// ProofOfBrowser: optional JS-gated submit token (form-mode only,
+	// #45/ADR-18). Blocks bots that POST directly without executing the
+	// page JavaScript that fetches the token. See ProofOfBrowserConfig.
+	ProofOfBrowser *ProofOfBrowserConfig `toml:"proof_of_browser"`
+}
+
+// ProofOfBrowserConfig configures the proof-of-browser check
+// (`[endpoints.proof_of_browser]`). Its presence enables the check.
+// Posthorn serves a challenge token from a GET on the endpoint; the
+// operator embeds a small script that fetches it and injects it as the
+// `_pob_token` field before submit. Form-mode only (ADR-18).
+type ProofOfBrowserConfig struct {
+	// Secret is the HMAC key for the challenge token. Optional: when
+	// empty, Posthorn generates a random one at startup (fine for a
+	// single replica). Set it explicitly for multi-replica deployments so
+	// every replica verifies the same tokens; ≥16 bytes when set.
+	Secret string `toml:"secret"`
+
+	// TTL is the token lifetime. Default 30m.
+	TTL Duration `toml:"ttl"`
+
+	// MinAge, when set, rejects a token submitted sooner than this after
+	// it was issued — a time-trap for bots that fetch-then-submit
+	// instantly. Must be less than the effective TTL.
+	MinAge Duration `toml:"min_age"`
 }
 
 // ReputationConfig configures the optional reputation check
@@ -206,6 +232,31 @@ func (r *ReputationConfig) validate() error {
 	}
 	if r.CacheTTL.Std() < 0 {
 		return fmt.Errorf("cache_ttl: must be non-negative, got %v", r.CacheTTL.Std())
+	}
+	return nil
+}
+
+// validate checks the proof_of_browser block. Called only for form-mode
+// endpoints (api-mode rejects the whole block above).
+func (p *ProofOfBrowserConfig) validate() error {
+	if p.Secret != "" {
+		if err := csrf.ValidateSecret([]byte(p.Secret)); err != nil {
+			return err
+		}
+	}
+	if p.TTL.Std() < 0 {
+		return fmt.Errorf("ttl: must be non-negative, got %v", p.TTL.Std())
+	}
+	if p.MinAge.Std() < 0 {
+		return fmt.Errorf("min_age: must be non-negative, got %v", p.MinAge.Std())
+	}
+	// Resolve the effective TTL for the min_age < ttl check (default 30m).
+	ttl := p.TTL.Std()
+	if ttl == 0 {
+		ttl = 30 * time.Minute
+	}
+	if p.MinAge.Std() >= ttl {
+		return fmt.Errorf("min_age (%v) must be less than ttl (%v)", p.MinAge.Std(), ttl)
 	}
 	return nil
 }
@@ -518,6 +569,9 @@ func (e *EndpointConfig) Validate() error {
 		if e.Reputation != nil {
 			return errors.New("reputation: not valid on auth=\"api-key\" endpoints (form-mode only in v1.1)")
 		}
+		if e.ProofOfBrowser != nil {
+			return errors.New("proof_of_browser: not valid on auth=\"api-key\" endpoints (server-to-server callers don't run a browser)")
+		}
 		// FR42: idempotency_cache_size must be positive when set; zero
 		// means "use the default" (handler-side resolution).
 		if e.IdempotencyCacheSize < 0 {
@@ -547,6 +601,11 @@ func (e *EndpointConfig) Validate() error {
 		if e.Reputation != nil {
 			if err := e.Reputation.validate(); err != nil {
 				return fmt.Errorf("reputation: %w", err)
+			}
+		}
+		if e.ProofOfBrowser != nil {
+			if err := e.ProofOfBrowser.validate(); err != nil {
+				return fmt.Errorf("proof_of_browser: %w", err)
 			}
 		}
 	}

--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/craigmccaskill/posthorn/captcha"
 	"github.com/craigmccaskill/posthorn/config"
 	"github.com/craigmccaskill/posthorn/csrf"
 	"github.com/craigmccaskill/posthorn/idempotency"
@@ -154,6 +155,43 @@ func (p *pobGate) verify(token string, now time.Time) error {
 	return nil
 }
 
+// turnstileField is the form field Cloudflare Turnstile's widget writes
+// its response token into (#33).
+const turnstileField = "cf-turnstile-response"
+
+// buildCaptchaCheck builds the Turnstile form check, or returns nil when
+// unconfigured. On a provider/transport error it fails closed by default
+// (silent reject) or open (allow, metered) per on_provider_error.
+func buildCaptchaCheck(cfg *config.CaptchaConfig) (formCheck, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	v, err := captcha.New(captcha.Config{
+		BaseURL: cfg.BaseURL,
+		Secret:  cfg.SecretKey,
+		Timeout: cfg.Timeout.Std(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	failClosed := cfg.OnProviderError != "open" // default closed
+	return func(ctx context.Context, form url.Values, clientIP string) spam.Verdict {
+		err := v.Verify(ctx, form.Get(turnstileField), clientIP)
+		switch {
+		case err == nil:
+			return spam.Verdict{}
+		case errors.Is(err, captcha.ErrFailed):
+			// Silent 200 (NFR5 parity) so a bot can't tell it was caught.
+			return spam.Verdict{Blocked: true, Silent: true, Kind: "captcha"}
+		case failClosed:
+			return spam.Verdict{Blocked: true, Silent: true, Kind: "captcha", Reason: "provider error (fail-closed)"}
+		default:
+			// Fail open: allow, but meter the bypass.
+			return spam.Verdict{Kind: "captcha", Reason: err.Error(), FailedOpen: true}
+		}
+	}, nil
+}
+
 // buildPOBGate constructs the proof-of-browser gate, generating a random
 // secret when the operator didn't set one (single-replica zero-config).
 func buildPOBGate(cfg *config.ProofOfBrowserConfig) (*pobGate, error) {
@@ -234,6 +272,10 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		// The proof-of-browser token field is structural (#45).
 		reserved = append(reserved, pobTokenField)
 	}
+	if cfg.Captcha != nil {
+		// The Turnstile response field is structural (#33).
+		reserved = append(reserved, turnstileField)
+	}
 
 	renderer, err := template.NewRenderer(cfg.Subject, cfg.Body, reserved)
 	if err != nil {
@@ -312,6 +354,11 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		return nil, fmt.Errorf("gateway: proof_of_browser: %w", err)
 	}
 
+	captchaCheck, err := buildCaptchaCheck(cfg.Captcha)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: captcha: %w", err)
+	}
+
 	h := &Handler{
 		cfg:                  cfg,
 		transport:            t,
@@ -327,7 +374,7 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		logger:               log.Discard(), // overridable via WithLogger
 		headerChecks:         buildHeaderChecks(cfg),
 		pob:                  pob,
-		formChecks:           buildFormChecks(cfg, csrfTTL, emailField, repChecker, pob),
+		formChecks:           buildFormChecks(cfg, csrfTTL, emailField, repChecker, pob, captchaCheck),
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -383,7 +430,7 @@ func buildReputationChecker(cfg *config.ReputationConfig) (*reputation.Checker, 
 }
 
 // buildFormChecks assembles the post-parse spam checks from config.
-func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailField string, rep *reputation.Checker, pob *pobGate) []formCheck {
+func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailField string, rep *reputation.Checker, pob *pobGate, captchaCheck formCheck) []formCheck {
 	var checks []formCheck
 	if cfg.Honeypot != "" {
 		field := cfg.Honeypot
@@ -415,6 +462,11 @@ func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailFiel
 			}
 			return spam.Verdict{}
 		})
+	}
+	if captchaCheck != nil {
+		// Turnstile verification (#33): the escalation tier for JS-capable
+		// bots. Network call; runs after the cheap local checks.
+		checks = append(checks, captchaCheck)
 	}
 	if rep != nil {
 		// Reputation lookup on the submitter email + client IP (#44).
@@ -467,11 +519,11 @@ func (h *Handler) applySpamVerdict(w http.ResponseWriter, r *http.Request, logge
 		if v.FailedOpen {
 			// A reputation lookup errored and we fail-open. Not blocked,
 			// but meter the bypass so a sustained outage is visible.
-			logger.Info("reputation_failed_open",
+			logger.Info(v.Kind+"_failed_open",
 				slog.String("kind", v.Kind),
 				slog.String("reason", v.Reason),
 			)
-			h.recorder.ReputationFailedOpen(h.cfg.Path)
+			h.recorder.CheckFailedOpen(h.cfg.Path, v.Kind)
 		}
 		return false
 	}

--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -10,6 +10,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -82,6 +83,11 @@ type Handler struct {
 	// check is a new builder entry, not another inline block in ServeHTTP.
 	headerChecks []headerCheck
 	formChecks   []formCheck
+
+	// pob serves the proof-of-browser challenge (a GET on the endpoint);
+	// nil unless [endpoints.proof_of_browser] is configured. The matching
+	// verify check lives in formChecks.
+	pob *pobGate
 }
 
 // headerCheck inspects the request before the body is parsed (headers, IP).
@@ -105,6 +111,68 @@ const (
 // defaultCSRFTokenTTL is the resolved value when cfg.CSRFTokenTTL is
 // zero (operator didn't set it). One hour matches FR57's stated default.
 const defaultCSRFTokenTTL = time.Hour
+
+// Proof-of-browser (#45, ADR-18): a JS-gated submit token. pobTokenField
+// is the hidden form field the operator's inline script populates from
+// the challenge endpoint. defaultPOBTokenTTL matches the issue's default.
+const (
+	pobTokenField      = "_pob_token"
+	defaultPOBTokenTTL = 30 * time.Minute
+)
+
+// errPOBTooNew is the min-age (time-trap) rejection.
+var errPOBTooNew = errors.New("proof-of-browser token submitted too soon after issuance")
+
+// pobGate issues and verifies proof-of-browser tokens. It reuses the
+// CSRF HMAC-timestamp machinery (ADR-18: same token format, different
+// issuer — Posthorn issues via the challenge endpoint rather than the
+// operator at render time) and adds an optional minimum-age floor.
+type pobGate struct {
+	secret []byte
+	ttl    time.Duration
+	minAge time.Duration
+}
+
+func (p *pobGate) issue(now time.Time) string { return csrf.Issue(p.secret, now) }
+
+func (p *pobGate) verify(token string, now time.Time) error {
+	if err := csrf.Verify(token, p.secret, p.ttl, now); err != nil {
+		return err
+	}
+	if p.minAge > 0 {
+		// Verify passed, so the token is "<unix>.<hmac>" with a valid
+		// timestamp; re-parse it for the age check.
+		tsStr := token[:strings.IndexByte(token, '.')]
+		unix, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil {
+			return err
+		}
+		if now.Sub(time.Unix(unix, 0)) < p.minAge {
+			return errPOBTooNew
+		}
+	}
+	return nil
+}
+
+// buildPOBGate constructs the proof-of-browser gate, generating a random
+// secret when the operator didn't set one (single-replica zero-config).
+func buildPOBGate(cfg *config.ProofOfBrowserConfig) (*pobGate, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	secret := []byte(cfg.Secret)
+	if len(secret) == 0 {
+		secret = make([]byte, 32)
+		if _, err := rand.Read(secret); err != nil {
+			return nil, fmt.Errorf("generate secret: %w", err)
+		}
+	}
+	ttl := cfg.TTL.Std()
+	if ttl == 0 {
+		ttl = defaultPOBTokenTTL
+	}
+	return &pobGate{secret: secret, ttl: ttl, minAge: cfg.MinAge.Std()}, nil
+}
 
 // Option configures a Handler at construction time.
 type Option func(*Handler)
@@ -161,6 +229,10 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 	if cfg.CSRFSecret != "" {
 		// FR57: the CSRF token field is structural, not template content.
 		reserved = append(reserved, csrf.TokenField)
+	}
+	if cfg.ProofOfBrowser != nil {
+		// The proof-of-browser token field is structural (#45).
+		reserved = append(reserved, pobTokenField)
 	}
 
 	renderer, err := template.NewRenderer(cfg.Subject, cfg.Body, reserved)
@@ -235,6 +307,11 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		return nil, fmt.Errorf("gateway: reputation: %w", err)
 	}
 
+	pob, err := buildPOBGate(cfg.ProofOfBrowser)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: proof_of_browser: %w", err)
+	}
+
 	h := &Handler{
 		cfg:                  cfg,
 		transport:            t,
@@ -249,7 +326,8 @@ func New(cfg config.EndpointConfig, t transport.Transport, opts ...Option) (*Han
 		csrfTokenTTL:         csrfTTL,
 		logger:               log.Discard(), // overridable via WithLogger
 		headerChecks:         buildHeaderChecks(cfg),
-		formChecks:           buildFormChecks(cfg, csrfTTL, emailField, repChecker),
+		pob:                  pob,
+		formChecks:           buildFormChecks(cfg, csrfTTL, emailField, repChecker, pob),
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -305,7 +383,7 @@ func buildReputationChecker(cfg *config.ReputationConfig) (*reputation.Checker, 
 }
 
 // buildFormChecks assembles the post-parse spam checks from config.
-func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailField string, rep *reputation.Checker) []formCheck {
+func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailField string, rep *reputation.Checker, pob *pobGate) []formCheck {
 	var checks []formCheck
 	if cfg.Honeypot != "" {
 		field := cfg.Honeypot
@@ -323,6 +401,17 @@ func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailFiel
 			token := form.Get(csrf.TokenField)
 			if err := csrf.Verify(token, secret, csrfTTL, time.Now()); err != nil {
 				return spam.Verdict{Blocked: true, Kind: "csrf", Event: "csrf_rejected", Reason: err.Error()}
+			}
+			return spam.Verdict{}
+		})
+	}
+	if pob != nil {
+		// Proof-of-browser (#45): the submission must carry a valid
+		// challenge token, which only the page JavaScript can fetch.
+		// Cheap local HMAC check — runs before the network reputation call.
+		checks = append(checks, func(_ context.Context, form url.Values, _ string) spam.Verdict {
+			if err := pob.verify(form.Get(pobTokenField), time.Now()); err != nil {
+				return spam.Verdict{Blocked: true, Kind: "proof_of_browser", Event: "pob_rejected", Reason: err.Error()}
 			}
 			return spam.Verdict{}
 		})
@@ -345,6 +434,28 @@ func buildFormChecks(cfg config.EndpointConfig, csrfTTL time.Duration, emailFiel
 		})
 	}
 	return checks
+}
+
+// serveChallenge answers a GET on a proof-of-browser endpoint with a
+// fresh token as JSON. When allowed_origins is configured, it enforces
+// the same origin allow-list so tokens can't be farmed from other sites;
+// it echoes an allowed Origin for CORS so a cross-origin form fetch can
+// read the token.
+func (h *Handler) serveChallenge(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin != "" && len(h.cfg.AllowedOrigins) > 0 {
+		if res, _ := spam.CheckOrigin(origin, "", h.cfg.AllowedOrigins); res == spam.HardReject {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
+	if origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Vary", "Origin")
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]string{"token": h.pob.issue(time.Now())})
 }
 
 // applySpamVerdict renders a blocking Verdict as the log line, metric, and
@@ -426,6 +537,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, h.maxBodySize)
 	}
 
+	// Proof-of-browser challenge: a GET on a PoB-enabled endpoint issues a
+	// fresh token for the page JavaScript to fetch and inject (#45,
+	// ADR-18). Every other non-POST method is still 405.
+	if r.Method == http.MethodGet && h.pob != nil {
+		h.serveChallenge(w, r)
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/core/gateway/handler_test.go
+++ b/core/gateway/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"mime/multipart"
 	"net/http"
@@ -2576,8 +2577,107 @@ func TestReputation_FailOpen_SendsAndMeters(t *testing.T) {
 	}
 	scrape := httptest.NewRecorder()
 	reg.Handler().ServeHTTP(scrape, httptest.NewRequest(http.MethodGet, "/metrics", nil))
-	if want := `posthorn_reputation_failed_open_total{endpoint="/contact"} 1`; !strings.Contains(scrape.Body.String(), want) {
+	if want := `posthorn_check_failed_open_total{endpoint="/contact",check="reputation"} 1`; !strings.Contains(scrape.Body.String(), want) {
 		t.Errorf("missing fail-open metric %q:\n%s", want, scrape.Body.String())
+	}
+}
+
+// --- Captcha / Turnstile (#33) ---
+
+func captchaEndpoint(baseURL, onError string) config.EndpointConfig {
+	return config.EndpointConfig{
+		Path:     "/test",
+		To:       []string{"ops@example.com"},
+		From:     "noreply@example.com",
+		Subject:  "Contact",
+		Body:     "{{.message}}",
+		Required: []string{"message"},
+		Captcha: &config.CaptchaConfig{
+			Provider:        "turnstile",
+			SecretKey:       "secret",
+			BaseURL:         baseURL,
+			OnProviderError: onError,
+		},
+	}
+}
+
+func fakeSiteverify(t *testing.T, success bool) string {
+	t.Helper()
+	body := `{"success":false}`
+	if success {
+		body = `{"success":true}`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestCaptcha_ValidToken_Sends(t *testing.T) {
+	rt := &recordingTransport{}
+	h, _ := gateway.New(captchaEndpoint(fakeSiteverify(t, true), ""), rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "cf-turnstile-response": {"tok"}}.Encode()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(rt.sent) != 1 {
+		t.Errorf("valid captcha sent %d messages, want 1", len(rt.sent))
+	}
+}
+
+func TestCaptcha_Rejected_SilentAndNoSend(t *testing.T) {
+	rt := &recordingTransport{}
+	h, _ := gateway.New(captchaEndpoint(fakeSiteverify(t, false), ""), rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "cf-turnstile-response": {"bad"}}.Encode()))
+	// NFR5 parity: rejection looks like success (silent 200) so a bot
+	// can't tell it was caught.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want silent 200 on rejection", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("rejected captcha still sent %d messages", len(rt.sent))
+	}
+}
+
+func TestCaptcha_ProviderError_FailClosed_NoSend(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := captchaEndpoint("http://127.0.0.1:1", "closed") // dead provider
+	cfg.Captcha.Timeout = config.Duration(200 * time.Millisecond)
+	h, _ := gateway.New(cfg, rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "cf-turnstile-response": {"tok"}}.Encode()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fail-closed status = %d, want silent 200", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("fail-closed on provider error still sent %d messages", len(rt.sent))
+	}
+}
+
+func TestCaptcha_ProviderError_FailOpen_SendsAndMeters(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := captchaEndpoint("http://127.0.0.1:1", "open") // dead provider
+	cfg.Captcha.Timeout = config.Duration(200 * time.Millisecond)
+	reg := metrics.New()
+	h, err := gateway.New(cfg, rt, gateway.WithRecorder(metrics.NewRecorder(reg)))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "cf-turnstile-response": {"tok"}}.Encode()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fail-open status = %d, want 200", rec.Code)
+	}
+	if len(rt.sent) != 1 {
+		t.Errorf("fail-open sent %d messages, want 1", len(rt.sent))
+	}
+	scrape := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(scrape, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if want := `posthorn_check_failed_open_total{endpoint="/test",check="captcha"} 1`; !strings.Contains(scrape.Body.String(), want) {
+		t.Errorf("missing captcha fail-open metric %q:\n%s", want, scrape.Body.String())
 	}
 }
 

--- a/core/gateway/handler_test.go
+++ b/core/gateway/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -2577,6 +2578,112 @@ func TestReputation_FailOpen_SendsAndMeters(t *testing.T) {
 	reg.Handler().ServeHTTP(scrape, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	if want := `posthorn_reputation_failed_open_total{endpoint="/contact"} 1`; !strings.Contains(scrape.Body.String(), want) {
 		t.Errorf("missing fail-open metric %q:\n%s", want, scrape.Body.String())
+	}
+}
+
+// --- Proof-of-browser (#45) ---
+
+func pobEndpoint(minAge time.Duration) config.EndpointConfig {
+	return config.EndpointConfig{
+		Path:     "/test",
+		To:       []string{"ops@example.com"},
+		From:     "noreply@example.com",
+		Subject:  "Contact",
+		Body:     "{{.message}}",
+		Required: []string{"message"},
+		ProofOfBrowser: &config.ProofOfBrowserConfig{
+			TTL:    config.Duration(time.Hour),
+			MinAge: config.Duration(minAge),
+		},
+	}
+}
+
+// fetchPOBToken performs the challenge GET and returns the issued token.
+func fetchPOBToken(t *testing.T, h *gateway.Handler) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/test", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("challenge status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("challenge body not JSON: %v", err)
+	}
+	if body.Token == "" {
+		t.Fatal("challenge returned an empty token")
+	}
+	return body.Token
+}
+
+func TestProofOfBrowser_ChallengeThenSubmit(t *testing.T) {
+	rt := &recordingTransport{}
+	h, err := gateway.New(pobEndpoint(0), rt)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	token := fetchPOBToken(t, h)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hello"}, "_pob_token": {token}}.Encode()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with a valid token; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(rt.sent) != 1 {
+		t.Errorf("valid submission sent %d messages, want 1", len(rt.sent))
+	}
+}
+
+func TestProofOfBrowser_MissingToken_Blocked(t *testing.T) {
+	rt := &recordingTransport{}
+	h, _ := gateway.New(pobEndpoint(0), rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}}.Encode()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("no token: status = %d, want 403", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("blocked submission still sent %d messages", len(rt.sent))
+	}
+}
+
+func TestProofOfBrowser_ForgedToken_Blocked(t *testing.T) {
+	rt := &recordingTransport{}
+	h, _ := gateway.New(pobEndpoint(0), rt)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "_pob_token": {"1700000000.deadbeef"}}.Encode()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("forged token: status = %d, want 403", rec.Code)
+	}
+}
+
+func TestProofOfBrowser_MinAge_TooSoon_Blocked(t *testing.T) {
+	// A 1h min-age with a token fetched and submitted immediately is the
+	// time-trap: age ~ 0 < min_age, so the instant POST is rejected.
+	rt := &recordingTransport{}
+	h, _ := gateway.New(pobEndpoint(time.Hour), rt)
+	token := fetchPOBToken(t, h)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest(url.Values{"message": {"hi"}, "_pob_token": {token}}.Encode()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("instant submit under min_age: status = %d, want 403", rec.Code)
+	}
+	if len(rt.sent) != 0 {
+		t.Errorf("time-trapped submission sent %d messages", len(rt.sent))
+	}
+}
+
+func TestProofOfBrowser_Challenge_EnforcesAllowedOrigins(t *testing.T) {
+	cfg := pobEndpoint(0)
+	cfg.AllowedOrigins = []string{"https://example.com"}
+	h, _ := gateway.New(cfg, &recordingTransport{})
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("challenge from disallowed origin: status = %d, want 403", rec.Code)
 	}
 }
 

--- a/core/metrics/recorder.go
+++ b/core/metrics/recorder.go
@@ -18,16 +18,16 @@ var LatencyBuckets = []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10}
 // without an enabling-condition check; tests that don't care about
 // metrics pass nil.
 type Recorder struct {
-	submitted            *Counter
-	sent                 *Counter
-	failed               *Counter
-	rateLimited          *Counter
-	authFailed           *Counter
-	spamBlocked          *Counter
-	reputationFailedOpen *Counter
-	validationFailed     *Counter
-	idempotentReplay     *Counter
-	sendLatency          *Histogram
+	submitted        *Counter
+	sent             *Counter
+	failed           *Counter
+	rateLimited      *Counter
+	authFailed       *Counter
+	spamBlocked      *Counter
+	checkFailedOpen  *Counter
+	validationFailed *Counter
+	idempotentReplay *Counter
+	sendLatency      *Histogram
 }
 
 // NewRecorder constructs a Recorder backed by counters and histograms
@@ -64,10 +64,10 @@ func NewRecorder(reg *Registry) *Recorder {
 			"Form-mode submissions rejected by spam defenses (honeypot/origin silent-200; csrf/reputation 403).",
 			[]string{"endpoint", "kind"},
 		),
-		reputationFailedOpen: NewCounter(
-			"posthorn_reputation_failed_open_total",
-			"Reputation lookups that errored and were allowed through (fail-open). A rising rate is a silent-bypass window.",
-			[]string{"endpoint"},
+		checkFailedOpen: NewCounter(
+			"posthorn_check_failed_open_total",
+			"Spam checks whose provider errored and were allowed through (fail-open). A rising rate is a silent-bypass window. check is \"reputation\" or \"captcha\".",
+			[]string{"endpoint", "check"},
 		),
 		validationFailed: NewCounter(
 			"posthorn_validation_failed_total",
@@ -92,7 +92,7 @@ func NewRecorder(reg *Registry) *Recorder {
 	reg.Register(r.rateLimited)
 	reg.Register(r.authFailed)
 	reg.Register(r.spamBlocked)
-	reg.Register(r.reputationFailedOpen)
+	reg.Register(r.checkFailedOpen)
 	reg.Register(r.validationFailed)
 	reg.Register(r.idempotentReplay)
 	reg.Register(r.sendLatency)
@@ -154,13 +154,15 @@ func (r *Recorder) SpamBlocked(endpoint, kind string) {
 	r.spamBlocked.Inc(endpoint, kind)
 }
 
-// ReputationFailedOpen records a reputation lookup that errored and was
-// allowed through (fail-open) — a silent-bypass signal for operators.
-func (r *Recorder) ReputationFailedOpen(endpoint string) {
+// CheckFailedOpen records a spam check whose provider errored and was
+// allowed through (fail-open) — a silent-bypass signal. check is the
+// operator-facing check name ("reputation", "captcha"), never submitter
+// content (NFR24).
+func (r *Recorder) CheckFailedOpen(endpoint, check string) {
 	if r == nil {
 		return
 	}
-	r.reputationFailedOpen.Inc(endpoint)
+	r.checkFailedOpen.Inc(endpoint, check)
 }
 
 // ValidationFailed records a 422 response for required-fields or

--- a/site/src/content/docs/configuration/reference.mdx
+++ b/site/src/content/docs/configuration/reference.mdx
@@ -165,6 +165,38 @@ fail_open  = true
 
 **Privacy:** enabling this sends the submitter's email and IP to StopForumSpam. It's off by default and opt-in. Note it in your privacy policy if your jurisdiction requires it.
 
+### Proof of browser (form-mode only)
+
+An optional `[endpoints.proof_of_browser]` block requires a token that only JavaScript can obtain, which blocks bots that POST the form directly without executing the page's script. It's content-agnostic and needs no third party. API-mode endpoints reject the block at parse time.
+
+```toml
+[endpoints.proof_of_browser]
+ttl     = "30m"
+min_age = "3s"   # optional time-trap: reject submissions faster than a human
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `secret` | string | no | random per start | HMAC key for the token. Leave unset for a single instance (a fresh random key is generated at startup). Set it (≥16 bytes) for multi-replica deployments so every replica verifies the same tokens. |
+| `ttl` | duration | no | `"30m"` | Token lifetime. |
+| `min_age` | duration | no | unset | When set, a token submitted sooner than this after issuance is rejected — a time-trap for bots that fetch-then-submit instantly. Must be less than `ttl`. |
+
+**How it works.** When enabled, a `GET` to the endpoint returns `{"token": "..."}`. Your form page fetches it and puts it in a hidden `_pob_token` field; Posthorn verifies it on submit. A missing, forged, expired, or too-new token is rejected with **403**. Add this to the page with your form (fetch on load so the token ages while the visitor types, which pairs with `min_age`):
+
+```html
+<form id="contact" action="https://posthorn.example.com/contact" method="POST">
+  <!-- your fields -->
+  <input type="hidden" name="_pob_token" value="">
+</form>
+<script>
+  fetch("https://posthorn.example.com/contact")
+    .then(r => r.json())
+    .then(d => { document.querySelector("#contact [name=_pob_token]").value = d.token; });
+</script>
+```
+
+If Posthorn is on a different host than the page, the challenge honors the endpoint's `allowed_origins` and sends the CORS header so the cross-origin `fetch` can read the token. Visitors with JavaScript disabled can't submit a proof-of-browser form, so keep it for public forms that get real bot traffic.
+
 ### Dry run
 
 | Field | Type | Required | Default | Description |

--- a/site/src/content/docs/configuration/reference.mdx
+++ b/site/src/content/docs/configuration/reference.mdx
@@ -197,6 +197,37 @@ min_age = "3s"   # optional time-trap: reject submissions faster than a human
 
 If Posthorn is on a different host than the page, the challenge honors the endpoint's `allowed_origins` and sends the CORS header so the cross-origin `fetch` can read the token. Visitors with JavaScript disabled can't submit a proof-of-browser form, so keep it for public forms that get real bot traffic.
 
+### Captcha (form-mode only)
+
+An optional `[endpoints.captcha]` block verifies a Cloudflare Turnstile token on submit — the escalation tier for high-spam targets, stopping bots that render JavaScript and would pass proof-of-browser. It adds a third-party dependency and a visible widget, so reach for it only when reputation and proof-of-browser aren't enough. API-mode endpoints reject the block at parse time.
+
+```toml
+[endpoints.captcha]
+provider          = "turnstile"
+secret_key        = "${env.TURNSTILE_SECRET_KEY}"
+on_provider_error = "closed"
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `provider` | string | yes | — | Only `"turnstile"` in this release. |
+| `secret_key` | string | yes | — | Turnstile secret key (server-side; never sent to the client). |
+| `on_provider_error` | string | no | `"closed"` | Behavior when Cloudflare can't be reached: `"closed"` rejects the submission (a captcha that fails open is weak), `"open"` allows it. Fail-open events increment `posthorn_check_failed_open_total{check="captcha"}`. |
+| `timeout` | duration | no | `"3s"` | Per-verification timeout. |
+| `base_url` | string | no | Cloudflare siteverify | Override the endpoint (testing). |
+
+A failed or missing token returns a byte-identical **200** (like the honeypot) so a bot can't tell it was caught. Add the Turnstile widget to your form; it writes the token into a `cf-turnstile-response` field that Posthorn verifies:
+
+```html
+<form action="https://posthorn.example.com/contact" method="POST">
+  <!-- your fields -->
+  <div class="cf-turnstile" data-sitekey="YOUR_TURNSTILE_SITE_KEY"></div>
+</form>
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+```
+
+The `secret_key` here is the Turnstile **secret** key; the `data-sitekey` in the widget is the **site** key. Get both from the Cloudflare Turnstile dashboard.
+
 ### Dry run
 
 | Field | Type | Required | Default | Description |


### PR DESCRIPTION
The escalation tier, stacked on #45. Completes the defense ladder: reputation → proof-of-browser → captcha.

Reputation (#44) and proof-of-browser (#45) already handle your observed spam (burner identities, non-JS bots). Turnstile is the backstop for a bot that renders a real browser and would pass proof-of-browser. Opt-in per endpoint because it's a third-party dependency and a visible widget.

## What's here

- `core/captcha` — a bespoke Turnstile siteverify client (stdlib http, ADR-1).
- Config: `[endpoints.captcha]` (`provider`, `secret_key`, `on_provider_error`, `timeout`, `base_url`), form-mode only.
- Pipeline form check. A failed/missing token returns a byte-identical **silent 200** (NFR5 parity) so a bot can't tell it was caught. On a provider error it **fails closed by default** (a captcha that fails open is weak), or open per config, with the bypass metered.
- Generalized the reputation fail-open metric into `posthorn_check_failed_open_total{endpoint,check}` so reputation and captcha share one counter (the reputation test moved to the new name in this diff since it's stacked).

## Tests

captcha package (accept/reject/empty-token/provider-error) + gateway integration (pass sends, reject silent-200, fail-closed blocks, fail-open sends + meters). gofmt/lint clean, 17 packages green with `-race`.

## The stack

#81 (reputation) → #82 (proof-of-browser) → this. Merge in order; GitHub retargets each as its base lands.

That's the "leads the release" tier of the spam milestone done. Remaining are robustness items (#62 single-use tokens, #61 on_spam visibility, #63 strict origin) and #32 CSRF min-age (which can now reuse the pobGate time-trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)