### PR TITLE
fix(smtp): wire ingress recorder + validate the listener (#57, #58)

### DIFF
--- a/core/cmd/posthorn/main.go
+++ b/core/cmd/posthorn/main.go
@@ -108,7 +108,13 @@ func runServe(args []string) error {
 		slog.Int("endpoints", len(cfg.Endpoints)),
 	)
 
-	mux, err := buildMux(cfg, logger)
+	// One metrics registry + recorder for the whole process, shared by the
+	// HTTP mux (which also exposes /metrics) and the SMTP ingress (#57) so
+	// SMTP submissions land in the same scrape as HTTP ones.
+	metricsReg := metrics.New()
+	recorder := metrics.NewRecorder(metricsReg)
+
+	mux, err := buildMux(cfg, logger, metricsReg, recorder)
 	if err != nil {
 		return fmt.Errorf("build router: %w", err)
 	}
@@ -143,7 +149,7 @@ func runServe(args []string) error {
 	// v1.0 block D: optional SMTP listener (FR62). Built only when the
 	// operator's TOML includes [smtp_listener].
 	if cfg.SMTPListener != nil {
-		smtpIng, err := buildSMTPIngress(cfg.SMTPListener, logger)
+		smtpIng, err := buildSMTPIngress(cfg.SMTPListener, logger, recorder)
 		if err != nil {
 			return fmt.Errorf("build smtp_listener: %w", err)
 		}
@@ -162,7 +168,7 @@ func runServe(args []string) error {
 // the smtp-package ListenerConfig, constructs the outbound transport
 // via the same registry the HTTP endpoints use, and returns the
 // resulting smtp.Listener (which satisfies ingress.Ingress).
-func buildSMTPIngress(c *config.SMTPListenerConfig, logger *slog.Logger) (ingress.Ingress, error) {
+func buildSMTPIngress(c *config.SMTPListenerConfig, logger *slog.Logger, recorder *metrics.Recorder) (ingress.Ingress, error) {
 	tp, err := buildTransport(c.Transport)
 	if err != nil {
 		return nil, fmt.Errorf("transport: %w", err)
@@ -199,7 +205,7 @@ func buildSMTPIngress(c *config.SMTPListenerConfig, logger *slog.Logger) (ingres
 	if err := listenerCfg.Validate(); err != nil {
 		return nil, err
 	}
-	return smtp.New(listenerCfg, tp, maxBody, logger, nil /* recorder wired by buildMux for HTTP only in v1.0 */)
+	return smtp.New(listenerCfg, tp, maxBody, logger, recorder)
 }
 
 // runIngressesUntilSignal starts each ingress in its own goroutine,
@@ -284,6 +290,16 @@ func runValidate(args []string) error {
 		}
 	}
 
+	// Build the SMTP ingress too (#58): its semantic checks (smtp_users
+	// required, TLS cert/key readable, client-cert CA parseable) live in
+	// buildSMTPIngress, not config.Load — so without this a listener-only
+	// config that passes `validate` could still fail at `serve`.
+	if cfg.SMTPListener != nil {
+		if _, err := buildSMTPIngress(cfg.SMTPListener, buildLogger(cfg.Logging), nil); err != nil {
+			return fmt.Errorf("smtp_listener: %w", err)
+		}
+	}
+
 	summary := fmt.Sprintf("%d endpoint(s)", len(cfg.Endpoints))
 	if cfg.SMTPListener != nil {
 		summary += " + smtp_listener"
@@ -302,11 +318,8 @@ func runValidate(args []string) error {
 // The mux additionally registers `/healthz` (FR54) and `/metrics`
 // (FR55) at fixed paths. Operators can firewall those paths at the
 // reverse proxy if internal-only access is desired.
-func buildMux(cfg *config.Config, logger *slog.Logger) (*http.ServeMux, error) {
+func buildMux(cfg *config.Config, logger *slog.Logger, metricsReg *metrics.Registry, recorder *metrics.Recorder) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
-
-	metricsReg := metrics.New()
-	recorder := metrics.NewRecorder(metricsReg)
 
 	for i, ep := range cfg.Endpoints {
 		t, err := buildTransport(ep.Transport)

--- a/core/cmd/posthorn/main_test.go
+++ b/core/cmd/posthorn/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/craigmccaskill/posthorn/config"
+	"github.com/craigmccaskill/posthorn/metrics"
 )
 
 // --- buildTransport ---
@@ -100,6 +101,32 @@ func TestRunValidate_Valid(t *testing.T) {
 	}
 }
 
+func TestRunValidate_SMTPListener_SemanticError(t *testing.T) {
+	// Structurally valid (config.Load passes) but the SMTP-level checks
+	// fail: require_tls defaults to true with no tls_cert. Before #58,
+	// runValidate skipped these and reported OK; now it must fail.
+	cfg := validTOML + `
+[smtp_listener]
+listen          = "127.0.0.1:2525"
+allowed_senders = ["*@example.com"]
+
+[[smtp_listener.smtp_users]]
+username = "u"
+password = "p"
+
+[smtp_listener.transport]
+type = "postmark"
+
+[smtp_listener.transport.settings]
+api_key = "k"
+`
+	path := writeConfig(t, cfg)
+	err := runValidate([]string{"--config", path})
+	if err == nil || !strings.Contains(err.Error(), "smtp_listener") {
+		t.Errorf("want an smtp_listener validation error, got %v", err)
+	}
+}
+
 func TestRunValidate_FileNotFound(t *testing.T) {
 	err := runValidate([]string{"--config", "/no/such/file.toml"})
 	if err == nil {
@@ -130,6 +157,16 @@ func TestRunValidate_TemplateParseError(t *testing.T) {
 
 // --- buildMux ---
 
+// muxRegRec builds the mux with a fresh shared registry + recorder, the
+// way runServe now wires them (#57). Tests scrape /metrics through the
+// mux, which uses this registry.
+func muxRegRec(cfg *config.Config) (*http.ServeMux, *metrics.Registry, *metrics.Recorder, error) {
+	reg := metrics.New()
+	rec := metrics.NewRecorder(reg)
+	mux, err := buildMux(cfg, buildLogger(config.LoggingConfig{}), reg, rec)
+	return mux, reg, rec, err
+}
+
 func TestBuildMux_RoutesEndpointsCorrectly(t *testing.T) {
 	cfg := &config.Config{
 		Endpoints: []config.EndpointConfig{
@@ -146,8 +183,7 @@ func TestBuildMux_RoutesEndpointsCorrectly(t *testing.T) {
 			},
 		},
 	}
-	logger := buildLogger(config.LoggingConfig{})
-	mux, err := buildMux(cfg, logger)
+	mux, _, _, err := muxRegRec(cfg)
 	if err != nil {
 		t.Fatalf("buildMux: %v", err)
 	}
@@ -182,7 +218,7 @@ func TestBuildMux_UnconfiguredPath_404(t *testing.T) {
 			},
 		},
 	}
-	mux, err := buildMux(cfg, buildLogger(config.LoggingConfig{}))
+	mux, _, _, err := muxRegRec(cfg)
 	if err != nil {
 		t.Fatalf("buildMux: %v", err)
 	}
@@ -210,7 +246,7 @@ func TestBuildMux_BadTransport_PropagatesError(t *testing.T) {
 			},
 		},
 	}
-	_, err := buildMux(cfg, buildLogger(config.LoggingConfig{}))
+	_, _, _, err := muxRegRec(cfg)
 	if err == nil {
 		t.Fatal("expected error for bad transport")
 	}
@@ -233,7 +269,7 @@ func TestBuildMux_HealthzRegistered(t *testing.T) {
 			},
 		},
 	}
-	mux, err := buildMux(cfg, buildLogger(config.LoggingConfig{}))
+	mux, _, _, err := muxRegRec(cfg)
 	if err != nil {
 		t.Fatalf("buildMux: %v", err)
 	}
@@ -265,7 +301,7 @@ func TestBuildMux_MetricsRegistered(t *testing.T) {
 			},
 		},
 	}
-	mux, err := buildMux(cfg, buildLogger(config.LoggingConfig{}))
+	mux, _, _, err := muxRegRec(cfg)
 	if err != nil {
 		t.Fatalf("buildMux: %v", err)
 	}
@@ -314,7 +350,7 @@ func TestBuildMux_MetricsObservedAfterRequest(t *testing.T) {
 			},
 		},
 	}
-	mux, err := buildMux(cfg, buildLogger(config.LoggingConfig{}))
+	mux, _, _, err := muxRegRec(cfg)
 	if err != nil {
 		t.Fatalf("buildMux: %v", err)
 	}

--- a/core/smtp/listener_test.go
+++ b/core/smtp/listener_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/http/httptest"
 	"net/textproto"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	"github.com/craigmccaskill/posthorn/config"
+	"github.com/craigmccaskill/posthorn/metrics"
 	"github.com/craigmccaskill/posthorn/transport"
 )
 
@@ -69,14 +71,18 @@ type smtpFixture struct {
 	cancel   context.CancelFunc
 }
 
-func startListener(t *testing.T, cfg ListenerConfig) *smtpFixture {
+func startListener(t *testing.T, cfg ListenerConfig, rec ...*metrics.Recorder) *smtpFixture {
 	t.Helper()
 	if cfg.MaxMessageSize == "" {
 		cfg.MaxMessageSize = "1MB"
 	}
 	mt := &mockTransport{}
 	maxBody := int64(1 << 20) // 1MB for tests
-	l, err := New(cfg, mt, maxBody, nil, nil)
+	var recorder *metrics.Recorder
+	if len(rec) > 0 {
+		recorder = rec[0]
+	}
+	l, err := New(cfg, mt, maxBody, nil, recorder)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -737,6 +743,34 @@ func TestSMTP_AuthNone_HappyPath_DeliversMessage(t *testing.T) {
 	waitForSend(t, f.mt, 1, 500*time.Millisecond)
 	if got := len(f.mt.Sent()); got != 1 {
 		t.Errorf("transport.Send calls = %d, want 1 (AuthNone happy path)", got)
+	}
+}
+
+// TestSMTP_RecorderWired asserts the SMTP ingress records metrics when a
+// recorder is provided (#57): before the fix, cmd/posthorn passed nil and
+// posthorn_submissions_sent_total{endpoint="smtp_listener"} never emitted.
+func TestSMTP_RecorderWired(t *testing.T) {
+	reg := metrics.New()
+	f := startListener(t, baseTestConfig(), metrics.NewRecorder(reg))
+	tp := f.dial()
+	_ = tp.PrintfLine("EHLO client.test")
+	expectMultiline(t, tp, 250)
+	_ = tp.PrintfLine("AUTH PLAIN %s", authPlainCreds("user", "pass"))
+	expect(t, tp, 235)
+	_ = tp.PrintfLine("MAIL FROM:<noreply@example.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("RCPT TO:<alice@somewhere.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("DATA")
+	expect(t, tp, 354)
+	_ = tp.PrintfLine("Subject: Hi\r\n\r\nBody.\r\n.")
+	expectCode(t, tp)
+	waitForSend(t, f.mt, 1, 2*time.Second)
+
+	scrape := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(scrape, httptest.NewRequest("GET", "/metrics", nil))
+	if want := `posthorn_submissions_sent_total{endpoint="smtp_listener",transport="postmark"} 1`; !strings.Contains(scrape.Body.String(), want) {
+		t.Errorf("missing %q in metrics:\n%s", want, scrape.Body.String())
 	}
 }
 

--- a/core/smtp/session.go
+++ b/core/smtp/session.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -401,6 +402,7 @@ func (s *session) handleDATA() {
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 	submissionID := uuid.NewString()
+	sendStart := time.Now()
 	result, sendErr := transport.SendWithRetry(ctx, s.l.transport, msg, s.logger)
 	if sendErr != nil {
 		_ = s.writeReply(451, "4.0.0 Upstream transport failed")
@@ -418,17 +420,17 @@ func (s *session) handleDATA() {
 		slog.String("transport_message_id", result.MessageID),
 		slog.Int64("size_bytes", n),
 	)
-	s.recordSendOk()
+	s.recordSendOk(time.Since(sendStart))
 	s.resetTransaction()
 }
 
-func (s *session) recordSendOk() {
+func (s *session) recordSendOk(latency time.Duration) {
 	if s.l.recorder == nil {
 		return
 	}
-	// Use a synthetic "smtp" ingress label so operators can split
+	// The "smtp_listener" endpoint label lets operators split
 	// inbound-via-HTTP from inbound-via-SMTP in metrics.
-	s.l.recorder.Sent("smtp_listener", s.l.cfg.Transport.Type, 0)
+	s.l.recorder.Sent("smtp_listener", s.l.cfg.Transport.Type, latency)
 }
 
 func (s *session) recordSendFailed(err error) {
@@ -437,29 +439,10 @@ func (s *session) recordSendFailed(err error) {
 	}
 	cls := "unknown"
 	var te *transport.TransportError
-	if asTransportError(err, &te) {
+	if errors.As(err, &te) {
 		cls = te.Class.String()
 	}
 	s.l.recorder.Failed("smtp_listener", s.l.cfg.Transport.Type, cls)
-}
-
-// asTransportError is a small wrapper around errors.As to avoid an
-// extra import line at the call site.
-func asTransportError(err error, out **transport.TransportError) bool {
-	for cur := err; cur != nil; cur = unwrap(cur) {
-		if te, ok := cur.(*transport.TransportError); ok {
-			*out = te
-			return true
-		}
-	}
-	return false
-}
-
-func unwrap(err error) error {
-	if u, ok := err.(interface{ Unwrap() error }); ok {
-		return u.Unwrap()
-	}
-	return nil
 }
 
 func (s *session) resetTransaction() {


### PR DESCRIPTION
Two audit-tail bugs in the SMTP ingress wiring.

## #57 — SMTP metrics were dead code

`cmd/posthorn` constructed the SMTP ingress with a **nil** `metrics.Recorder` (with a comment that it was "HTTP only in v1.0"), so `posthorn_submissions_sent_total{endpoint="smtp_listener"}` and the failure counter never emitted — SMTP traffic was invisible on `/metrics`. Fix: hoist the registry + recorder to `runServe` and share them between `buildMux` and `buildSMTPIngress`. Also records the real send latency (was hardcoded `0`) and swaps the hand-rolled `asTransportError`/`unwrap` for `errors.As`.

## #58 — `validate` skipped the SMTP listener

`posthorn validate` constructed transports + handlers for HTTP endpoints but never ran the SMTP-level checks (`smtp_users` required, TLS cert/key readable, client-cert CA parseable) — those live in `buildSMTPIngress`, only reached on `serve`. So a listener config could pass `validate` and then fail at boot. `runValidate` now builds the SMTP ingress too.

## Tests

- smtp: a delivered message increments `submissions_sent_total{endpoint="smtp_listener"}` when a recorder is wired.
- cmd: a structurally-valid-but-SMTP-invalid listener config (require_tls default, no `tls_cert`) is now rejected by `validate`.

gofmt/lint clean, 17 packages green with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)