### PR TITLE
docs(recipes): Authentik and Mastodon

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -103,6 +103,8 @@ export default defineConfig({
             { label: 'Hugo blog + Comentario comments', slug: 'recipes/hugo-comentario' },
             { label: 'Self-hosted Gitea', slug: 'recipes/gitea' },
             { label: 'Self-hosted Ghost', slug: 'recipes/ghost' },
+            { label: 'Self-hosted Authentik', slug: 'recipes/authentik' },
+            { label: 'Self-hosted Mastodon', slug: 'recipes/mastodon' },
             { label: 'Weekly Umami digest (API mode)', slug: 'recipes/umami' },
           ],
         },

--- a/site/src/content/docs/recipes/authentik.mdx
+++ b/site/src/content/docs/recipes/authentik.mdx
@@ -1,0 +1,99 @@
+---
+title: Self-hosted Authentik via Posthorn
+description: Route Authentik's transactional mail (email verification, password recovery, MFA enrollment) through Posthorn's SMTP listener, so your identity provider reaches a transactional provider without the host needing outbound SMTP.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+You're running [Authentik](https://goauthentik.io) as your identity provider. Authentik sends email for account verification, password recovery, and MFA enrollment. On a cloud VPS that blocks outbound SMTP, or when you simply don't want to hand Authentik your provider credentials, Posthorn's SMTP listener accepts Authentik's connection on a private Docker network and forwards over HTTPS to whichever transactional provider you've chosen.
+
+**At the end:** Authentik points its email settings at `posthorn:2525` over a private Docker network — no TLS, no AUTH — and Posthorn forwards via the configured HTTP transport to Postmark, Resend, Mailgun, or SES.
+
+## The shape
+
+```d2
+direction: right
+host: Docker host {
+  authentik: Authentik\n(server + worker)
+  posthorn: "Posthorn\nSMTP listener (auth=none)"
+  authentik -> posthorn: "SMTP on posthorn:2525\n(internal network)"
+}
+provider: "Postmark · Resend\nMailgun · SES"
+host.posthorn -> provider: HTTPS
+```
+
+Only the Authentik **worker** sends mail, but pointing both server and worker at Posthorn is simplest and harmless.
+
+## Walkthrough
+
+<Steps>
+
+1. **Put Posthorn and Authentik on the same private Docker network** (no `ports:` exposure for Posthorn):
+
+   ```yaml
+   # docker-compose.yml (excerpt)
+   networks:
+     internal:
+       internal: true
+   services:
+     posthorn:
+       image: ghcr.io/craigmccaskill/posthorn:latest
+       restart: unless-stopped
+       volumes:
+         - ./posthorn.toml:/etc/posthorn/config.toml:ro
+       env_file: .env
+       networks: [internal]
+       # no ports: — reachable only from inside the network
+   ```
+
+2. **Write `posthorn.toml`.**
+
+   ```toml
+   [smtp_listener]
+   listen          = ":2525"
+   auth_required   = "none"
+   require_tls     = false
+   trusted_network = true            # asserts the Docker network is the trust boundary (#41)
+   allowed_senders = ["*@yourdomain.com"]
+
+   [smtp_listener.transport]
+   type = "postmark"
+
+   [smtp_listener.transport.settings]
+   api_key = "${env.POSTMARK_API_KEY}"
+   ```
+
+   <Aside type="caution" title="trusted_network is required">
+   Since v1.1, `auth_required = "none"` on a non-loopback bind (like `:2525` inside a container) refuses to start unless you set `trusted_network = true`. That flag is your explicit statement that the network is the trust boundary — which, with no `ports:` exposure, it is.
+   </Aside>
+
+3. **Point Authentik at Posthorn** via environment (applies to both `server` and `worker`):
+
+   ```yaml
+   environment:
+     AUTHENTIK_EMAIL__HOST: posthorn
+     AUTHENTIK_EMAIL__PORT: "2525"
+     AUTHENTIK_EMAIL__USE_TLS: "false"
+     AUTHENTIK_EMAIL__USE_SSL: "false"
+     AUTHENTIK_EMAIL__FROM: "authentik@yourdomain.com"
+     # AUTHENTIK_EMAIL__USERNAME / __PASSWORD intentionally unset
+   ```
+
+4. **Start the stack and test.** In the Authentik admin interface, use *System → Settings → Test email* (or trigger a password recovery). Posthorn logs the session:
+
+   ```json
+   {"msg":"smtp_session_open","ingress":"smtp"}
+   {"msg":"smtp_submission_sent","transport_message_id":"..."}
+   ```
+
+</Steps>
+
+## Common gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Authentik logs a TLS handshake error | `AUTHENTIK_EMAIL__USE_TLS` / `USE_SSL` still `true` | Set both to `false`; the listener runs plaintext on the internal network |
+| `550 5.7.1 Sender not authorized` | `AUTHENTIK_EMAIL__FROM` isn't on `allowed_senders` | Add the address (or a `*@domain` wildcard) |
+| Posthorn won't start: `auth_required = "none"` refused | Missing the trust ack | Add `trusted_network = true`, and keep the listener off any host port |
+
+See [Internal SMTP relay](/recipes/internal-smtp-relay/) for the full reasoning on the auth-none + private-network model.

--- a/site/src/content/docs/recipes/mastodon.mdx
+++ b/site/src/content/docs/recipes/mastodon.mdx
@@ -1,0 +1,81 @@
+---
+title: Self-hosted Mastodon via Posthorn
+description: Route a self-hosted Mastodon instance's transactional mail (confirmations, password resets, notifications) through Posthorn's SMTP listener, without giving Mastodon your provider credentials or needing outbound SMTP on the host.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+You're running a self-hosted [Mastodon](https://joinmastodon.org) instance. Mastodon sends email for account confirmation, password resets, and notification digests via SMTP. On a cloud host that blocks outbound SMTP — or when you'd rather keep your provider key in one place — Posthorn's SMTP listener accepts Mastodon's connection on a private network and forwards over HTTPS to your transactional provider.
+
+**At the end:** Mastodon's `sidekiq` (which sends the mail) talks to `posthorn:2525` over a private Docker network with no TLS and no AUTH, and Posthorn forwards via the configured HTTP transport.
+
+## The shape
+
+```d2
+direction: right
+host: Docker host {
+  mastodon: "Mastodon\nweb + sidekiq"
+  posthorn: "Posthorn\nSMTP listener (auth=none)"
+  mastodon -> posthorn: "SMTP on posthorn:2525\n(internal network)"
+}
+provider: "Postmark · Resend\nMailgun · SES"
+host.posthorn -> provider: HTTPS
+```
+
+## Walkthrough
+
+<Steps>
+
+1. **Same private Docker network, no host-port exposure for Posthorn** (see the [Authentik recipe](/recipes/authentik/) for the compose skeleton — it's identical).
+
+2. **Write `posthorn.toml`.**
+
+   ```toml
+   [smtp_listener]
+   listen          = ":2525"
+   auth_required   = "none"
+   require_tls     = false
+   trusted_network = true            # required for auth "none" on a container bind (#41)
+   allowed_senders = ["*@yourdomain.com"]
+
+   [smtp_listener.transport]
+   type = "resend"
+
+   [smtp_listener.transport.settings]
+   api_key = "${env.RESEND_API_KEY}"
+   ```
+
+3. **Point Mastodon at Posthorn** in its `.env.production` (read by both `web` and `sidekiq`):
+
+   ```bash
+   SMTP_SERVER=posthorn
+   SMTP_PORT=2525
+   SMTP_LOGIN=
+   SMTP_PASSWORD=
+   SMTP_AUTH_METHOD=none
+   SMTP_OPENSSL_VERIFY_MODE=none
+   SMTP_ENABLE_STARTTLS=never
+   SMTP_FROM_ADDRESS=Mastodon <notifications@yourdomain.com>
+   ```
+
+   `SMTP_ENABLE_STARTTLS=never` and the empty `SMTP_LOGIN`/`SMTP_PASSWORD` are the important ones — they keep Mastodon from trying to upgrade the connection or authenticate, which matches the plaintext-on-the-internal-network listener.
+
+4. **Test the delivery path** with Mastodon's built-in mailer task:
+
+   ```bash
+   docker compose run --rm web bin/tootctl email test you@example.com
+   ```
+
+   Posthorn logs `smtp_submission_sent` with the provider's `transport_message_id`.
+
+</Steps>
+
+## Common gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Sidekiq mailer job retries with a TLS error | `SMTP_ENABLE_STARTTLS` not `never` | Set `SMTP_ENABLE_STARTTLS=never` (older Mastodon: `SMTP_TLS=false`, `SMTP_ENABLE_STARTTLS_AUTO=false`) |
+| `530 5.7.0 Must issue STARTTLS first` from Posthorn | Listener has `require_tls = true` | Set `require_tls = false` for the internal-network deployment |
+| `550 5.7.1 Sender not authorized` | `SMTP_FROM_ADDRESS` domain not in `allowed_senders` | Add `*@yourdomain.com` |
+
+Mail sends from `sidekiq`, so check its logs (not `web`) when debugging delivery. See [Internal SMTP relay](/recipes/internal-smtp-relay/) for the trust model behind `auth_required = "none"`.


### PR DESCRIPTION
Two recipes for apps the splash page and roadmap already claim support for but had no walkthrough. Both are the internal-SMTP-relay shape (auth-none on a private Docker network → HTTP transport).

- **Authentik** — `AUTHENTIK_EMAIL__*` env vars, USE_TLS/USE_SSL gotcha, mail-from-worker note.
- **Mastodon** — `.env.production` SMTP vars, `SMTP_ENABLE_STARTTLS=never`, and the mail-sends-from-sidekiq debugging note.

Both include `trusted_network = true` since v1.1's #41 change requires it for auth-none on a container bind, so the recipes are correct against the current release. Added to the recipes sidebar; site builds (51 pages).

Part of the discoverability push from the product audit — each recipe is a landing page for "does X work with Posthorn" searches. Next candidates: Nextcloud, Vaultwarden, Grafana/Alertmanager, WordPress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)