### PR TITLE
feat: Postmark lifecycle events + minimal suppression (#8, #4, Epic 15)

### DIFF
--- a/core/cmd/posthorn/main.go
+++ b/core/cmd/posthorn/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/craigmccaskill/posthorn/config"
 	"github.com/craigmccaskill/posthorn/gateway"
 	"github.com/craigmccaskill/posthorn/ingress"
+	"github.com/craigmccaskill/posthorn/lifecycle"
 	"github.com/craigmccaskill/posthorn/metrics"
 	"github.com/craigmccaskill/posthorn/smtp"
 	"github.com/craigmccaskill/posthorn/spam"
@@ -43,8 +44,9 @@ var version = "v0.0.1-dev"
 const usage = `posthorn — the unified outbound mail layer for self-hosted projects.
 
 Usage:
-  posthorn serve     [--config <path>] [--listen <addr>]
-  posthorn validate  [--config <path>]
+  posthorn serve         [--config <path>] [--listen <addr>]
+  posthorn validate      [--config <path>]
+  posthorn suppressions  <list | add <email> [--reason <r>] | remove <email>> [--config <path>]
   posthorn version
   posthorn help
 
@@ -54,6 +56,9 @@ Default listen addr:  :8080
 Examples:
   posthorn serve --config ./posthorn.toml --listen :8080
   posthorn validate --config ./posthorn.toml
+  posthorn suppressions list --config ./posthorn.toml
+  posthorn suppressions add bounced@example.com --config ./posthorn.toml
+  posthorn suppressions remove bounced@example.com --config ./posthorn.toml
 `
 
 func main() {
@@ -73,6 +78,11 @@ func main() {
 		}
 	case "validate":
 		if err := runValidate(args); err != nil {
+			fmt.Fprintln(os.Stderr, "posthorn:", err)
+			os.Exit(1)
+		}
+	case "suppressions":
+		if err := runSuppressions(args); err != nil {
 			fmt.Fprintln(os.Stderr, "posthorn:", err)
 			os.Exit(1)
 		}
@@ -215,6 +225,31 @@ func runServe(args []string) error {
 			OnHealth: recorder.SetStorageHealthy,
 			OnDepth:  recorder.SetQueueDepth,
 		})
+
+		// v2.0: lifecycle event ingestion + callback forwarding (FR82-FR85).
+		if cfg.Lifecycle != nil {
+			webhooks := map[string]lifecycle.Webhook{}
+			for _, ep := range cfg.Endpoints {
+				if ep.WebhookURL != "" {
+					webhooks[ep.Path] = lifecycle.Webhook{URL: ep.WebhookURL, Secret: ep.WebhookSecret}
+				}
+			}
+			fwd := &lifecycle.Forwarder{
+				Webhooks: webhooks,
+				Gate:     gate,
+				Logger:   logger,
+				OnResult: recorder.LifecycleForward,
+			}
+			eventsHandler, err := lifecycle.NewHandler(
+				cfg.Lifecycle.BasicAuthUsername, cfg.Lifecycle.BasicAuthPassword,
+				gate, fwd, logger, recorder)
+			if err != nil {
+				return fmt.Errorf("build lifecycle handler: %w", err)
+			}
+			mux.Handle("/events/postmark", eventsHandler)
+			go fwd.RunQueue(ctx, 0)
+			logger.Info("lifecycle_enabled", slog.Int("webhook_endpoints", len(webhooks)))
+		}
 	}
 
 	return runIngressesUntilSignal(ingresses, logger)

--- a/core/cmd/posthorn/suppressions.go
+++ b/core/cmd/posthorn/suppressions.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/craigmccaskill/posthorn/config"
+	"github.com/craigmccaskill/posthorn/spam"
+	"github.com/craigmccaskill/posthorn/storage"
+)
+
+// runSuppressions implements `posthorn suppressions` (FR87, ADR-23) —
+// the management and GDPR-erasure surface for the suppression list.
+// Operates directly on the configured storage file; there is no HTTP
+// admin API by design. Run it against a live instance's file freely:
+// SQLite WAL handles a concurrent reader/writer from the same host.
+func runSuppressions(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("suppressions: subcommand required: list | add <email> | remove <email>")
+	}
+	sub := args[0]
+	rest := args[1:]
+
+	// add/remove take the email as the first positional after the verb.
+	var email string
+	if sub == "add" || sub == "remove" {
+		if len(rest) < 1 || len(rest[0]) == 0 || rest[0][0] == '-' {
+			return fmt.Errorf("suppressions %s: email argument required", sub)
+		}
+		email = rest[0]
+		rest = rest[1:]
+	}
+
+	fs := flag.NewFlagSet("suppressions "+sub, flag.ContinueOnError)
+	configPath := fs.String("config", "/etc/posthorn/config.toml", "path to TOML config file")
+	reason := fs.String("reason", storage.ReasonManual, "suppression reason (add only)")
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+
+	st, err := openConfiguredStore(*configPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.Close() }()
+
+	switch sub {
+	case "list":
+		rows, err := st.ListSuppressions(10000)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("no suppressions")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "EMAIL\tREASON\tSOURCE\tSINCE")
+		for _, r := range rows {
+			src := r.SourceEndpoint
+			if src == "" {
+				src = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Email, r.Reason, src, r.CreatedAt.Format(time.RFC3339))
+		}
+		return w.Flush()
+
+	case "add":
+		if err := st.AddSuppression(email, *reason, "", time.Now()); err != nil {
+			return err
+		}
+		fmt.Printf("suppressed %s (%s)\n", email, *reason)
+		return nil
+
+	case "remove":
+		n, err := st.RemoveSuppression(email)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			fmt.Printf("%s was not suppressed\n", email)
+		} else {
+			fmt.Printf("removed %s (%d entr%s)\n", email, n, plural(n, "y", "ies"))
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("suppressions: unknown subcommand %q (want list | add | remove)", sub)
+	}
+}
+
+// openConfiguredStore loads the config and opens its storage file.
+func openConfiguredStore(configPath string) (*storage.Store, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Storage == nil {
+		return nil, fmt.Errorf("no [storage] block in %s — suppressions need the storage layer", configPath)
+	}
+	maxSize, err := spam.ParseSize(cfg.Storage.EffectiveMaxSize())
+	if err != nil {
+		return nil, fmt.Errorf("storage.max_size: %w", err)
+	}
+	return storage.Open(storage.Config{
+		Path:      cfg.Storage.Path,
+		InMemory:  cfg.Storage.InMemory,
+		Retention: cfg.Storage.EffectiveRetention(),
+		MaxSize:   maxSize,
+	})
+}
+
+func plural(n int64, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/core/cmd/posthorn/suppressions_test.go
+++ b/core/cmd/posthorn/suppressions_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FR87: the suppressions CLI round-trip against a real storage file.
+
+func suppressionsConfig(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "posthorn.db")
+	return writeConfig(t, validTOML+`
+[storage]
+path = "`+dbPath+`"
+`)
+}
+
+func TestSuppressionsCLI_AddListRemove(t *testing.T) {
+	cfgPath := suppressionsConfig(t)
+
+	if err := runSuppressions([]string{"add", "bounced@example.com", "--config", cfgPath}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := runSuppressions([]string{"list", "--config", cfgPath}); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if err := runSuppressions([]string{"remove", "bounced@example.com", "--config", cfgPath}); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// Second remove is a no-op, not an error.
+	if err := runSuppressions([]string{"remove", "bounced@example.com", "--config", cfgPath}); err != nil {
+		t.Fatalf("second remove: %v", err)
+	}
+}
+
+func TestSuppressionsCLI_AddWithReason(t *testing.T) {
+	cfgPath := suppressionsConfig(t)
+	if err := runSuppressions([]string{"add", "x@example.com", "--reason", "hard_bounce", "--config", cfgPath}); err != nil {
+		t.Fatalf("add --reason: %v", err)
+	}
+}
+
+func TestSuppressionsCLI_Errors(t *testing.T) {
+	cfgPath := suppressionsConfig(t)
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no subcommand", []string{}, "subcommand required"},
+		{"unknown subcommand", []string{"purge", "--config", cfgPath}, "unknown subcommand"},
+		{"add without email", []string{"add", "--config", cfgPath}, "email argument required"},
+		{"remove without email", []string{"remove", "--config", cfgPath}, "email argument required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runSuppressions(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSuppressionsCLI_RequiresStorageBlock(t *testing.T) {
+	cfgPath := writeConfig(t, validTOML) // no [storage]
+	err := runSuppressions([]string{"list", "--config", cfgPath})
+	if err == nil || !strings.Contains(err.Error(), "[storage]") {
+		t.Fatalf("err = %v, want storage-required error", err)
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/mail"
 	"net/netip"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -28,6 +29,29 @@ type Config struct {
 	Logging      LoggingConfig       `toml:"logging"`
 	SMTPListener *SMTPListenerConfig `toml:"smtp_listener"`
 	Storage      *StorageConfig      `toml:"storage"`
+	Lifecycle    *LifecycleConfig    `toml:"lifecycle"`
+}
+
+// LifecycleConfig is the optional top-level [lifecycle] block (FR82,
+// ADR-22). Presence enables the Postmark event-ingestion endpoint
+// (`/events/postmark`) on the main HTTP listener. Requires [storage]
+// (event correlation reads the submission log) — enforced in
+// Config.Validate. Basic auth is mandatory and fail-closed: Posthorn's
+// first inbound-from-a-third-party surface never runs open (NFR25).
+type LifecycleConfig struct {
+	// BasicAuthUsername/BasicAuthPassword protect the event endpoint.
+	// Postmark supports setting both on the webhook URL natively. The
+	// password falls under NFR3/NFR29: never logged.
+	BasicAuthUsername string `toml:"basic_auth_username"`
+	BasicAuthPassword string `toml:"basic_auth_password"`
+}
+
+// Validate runs structural checks on the lifecycle block.
+func (l *LifecycleConfig) Validate() error {
+	if l.BasicAuthUsername == "" || l.BasicAuthPassword == "" {
+		return errors.New("basic_auth_username and basic_auth_password are required (the event endpoint never runs unauthenticated)")
+	}
+	return nil
 }
 
 // StorageConfig is the optional top-level [storage] block (FR76,
@@ -234,6 +258,17 @@ type EndpointConfig struct {
 	// #33). The escalation tier — stops bots that render JS. See
 	// CaptchaConfig.
 	Captcha *CaptchaConfig `toml:"captcha"`
+
+	// v2.0 block E: lifecycle callbacks (FR84). When WebhookURL is set,
+	// normalized delivery/bounce/complaint events for mail sent through
+	// this endpoint are POSTed there, signed with HMAC-SHA256 of the
+	// body under WebhookSecret (X-Posthorn-Signature: sha256=<hex>).
+	// Requires the top-level [lifecycle] block — a webhook_url with no
+	// event ingestion would never fire, which is exactly the
+	// looks-configured-but-isn't footgun ADR-10 exists to prevent.
+	// WebhookSecret falls under NFR3/NFR29: never logged.
+	WebhookURL    string `toml:"webhook_url"`
+	WebhookSecret string `toml:"webhook_secret"`
 }
 
 // CaptchaConfig configures the optional captcha check
@@ -538,6 +573,22 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// FR82: lifecycle rides the submission log; without storage there is
+	// nothing to correlate events against.
+	if c.Lifecycle != nil {
+		if err := c.Lifecycle.Validate(); err != nil {
+			return fmt.Errorf("lifecycle: %w", err)
+		}
+		if c.Storage == nil {
+			return errors.New("lifecycle: requires a [storage] block (event correlation reads the submission log)")
+		}
+	}
+	for i, ep := range c.Endpoints {
+		if ep.WebhookURL != "" && c.Lifecycle == nil {
+			return fmt.Errorf("endpoints[%d] (%s): webhook_url requires a top-level [lifecycle] block — without event ingestion the callback would never fire", i, ep.Path)
+		}
+	}
+
 	return nil
 }
 
@@ -664,6 +715,22 @@ func (e *EndpointConfig) Validate() error {
 	}
 	if e.TextBody != "" && e.BodyFormat != BodyFormatHTML {
 		return errors.New("text_body: only valid when body_format = \"html\" (text endpoints render body directly; there is no fallback part)")
+	}
+
+	// FR84: webhook callback pairing. The secret gate is ≥16 bytes —
+	// HMAC with a short secret is decorative (proof_of_browser
+	// precedent).
+	if e.WebhookURL != "" {
+		u, err := url.Parse(e.WebhookURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return fmt.Errorf("webhook_url: must be an absolute http(s) URL, got %q", e.WebhookURL)
+		}
+		if len(e.WebhookSecret) < 16 {
+			return errors.New("webhook_secret: required with webhook_url and must be at least 16 bytes")
+		}
+	}
+	if e.WebhookSecret != "" && e.WebhookURL == "" {
+		return errors.New("webhook_secret: only valid alongside webhook_url")
 	}
 
 	if err := e.Transport.Validate(); err != nil {

--- a/core/gateway/handler.go
+++ b/core/gateway/handler.go
@@ -931,6 +931,28 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// FR86: drop suppressed recipients before the send. All suppressed →
+	// terminally handled as "suppressed", nothing sent. Lookup failures
+	// fail open (send anyway) — mail first, NFR27.
+	var suppressed map[string]string
+	msg.To, suppressed = h.filterSuppressed(msg.To)
+	if len(suppressed) > 0 {
+		h.recorder.Suppressed(h.cfg.Path, len(suppressed))
+		logger.Info("recipients_suppressed", slog.Int("count", len(suppressed)))
+	}
+	if len(msg.To) == 0 {
+		h.recordSuppressedSubmission(submissionID, msg, r)
+		logger.Info("submission_suppressed",
+			slog.Int64("latency_ms", time.Since(start).Milliseconds()),
+		)
+		h.writeSuccessResponse(w, r, response.Success{
+			Status:       "suppressed",
+			SubmissionID: submissionID,
+			Suppressed:   suppressed,
+		})
+		return
+	}
+
 	// FR77: persist the submission (status "sending") before the send so
 	// a crash mid-send is recoverable (NFR28). Best-effort: a storage
 	// failure degrades, never blocks (NFR27).
@@ -1012,7 +1034,65 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.writeSuccessResponse(w, r, response.Success{
 		Status:       "ok",
 		SubmissionID: submissionID,
+		Suppressed:   suppressed,
 	})
+}
+
+// filterSuppressed splits recipients into sendable and suppressed
+// (FR86). Without storage, or degraded, everything is sendable — the
+// v1.x path untouched. Lookup errors fail open per-recipient.
+func (h *Handler) filterSuppressed(to []string) (remaining []string, suppressed map[string]string) {
+	g := h.storageGate
+	if g == nil || !g.Healthy() {
+		return to, nil
+	}
+	remaining = make([]string, 0, len(to))
+	for _, addr := range to {
+		sup, ok, err := g.Store().SuppressionFor(addr)
+		if err != nil {
+			g.ReportError(err)
+			remaining = append(remaining, addr)
+			continue
+		}
+		if ok {
+			if suppressed == nil {
+				suppressed = map[string]string{}
+			}
+			suppressed[addr] = sup.Reason
+			continue
+		}
+		remaining = append(remaining, addr)
+	}
+	return remaining, suppressed
+}
+
+// recordSuppressedSubmission logs an all-recipients-suppressed
+// submission (status "suppressed", FR86) in the submission log.
+func (h *Handler) recordSuppressedSubmission(id string, msg transport.Message, r *http.Request) {
+	g := h.storageGate
+	if g == nil || !g.Healthy() {
+		return
+	}
+	sub := storage.Submission{
+		ID:        id,
+		Endpoint:  h.cfg.Path,
+		Transport: h.cfg.Transport.Type,
+		Status:    storage.StatusSuppressed,
+		CreatedAt: time.Now(),
+	}
+	if h.logFailedSubmissions {
+		sub.From = msg.From
+		sub.Subject = msg.Subject
+		sub.BodyText = msg.BodyText
+		sub.BodyHTML = msg.BodyHTML
+		sub.Fields = storableFields(r.Form, h.cfg.Honeypot)
+		if !h.cfg.StripClientIP {
+			sub.ClientIP = ratelimit.ClientIP(r, h.trustedProxies)
+		}
+	}
+	if err := g.Store().RecordSubmission(sub); err != nil {
+		g.ReportError(err)
+	}
 }
 
 // AttachStorage wires the optional storage gate (FR76). Called by

--- a/core/gateway/suppression_test.go
+++ b/core/gateway/suppression_test.go
@@ -1,0 +1,142 @@
+package gateway_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/craigmccaskill/posthorn/config"
+	"github.com/craigmccaskill/posthorn/gateway"
+	"github.com/craigmccaskill/posthorn/storage"
+)
+
+// FR86: send-time suppression. The response contract is "2xx =
+// terminally handled; the body names the outcome".
+
+func multiRecipientHandler(t *testing.T, tr *recordingTransport) *gateway.Handler {
+	t.Helper()
+	cfg := config.EndpointConfig{
+		Path:    "/test",
+		To:      []string{"clean@example.com", "bounced@example.com"},
+		From:    "from@example.com",
+		Subject: "S",
+		Body:    "B",
+	}
+	h, err := gateway.New(cfg, tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestSuppression_AllSuppressed_200SuppressedNoSend(t *testing.T) {
+	tr := &recordingTransport{}
+	h := newTestHandler(t, tr) // single recipient to@example.com
+	gate := newGate(t)
+	if err := gate.Store().AddSuppression("to@example.com", storage.ReasonHardBounce, "/test", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	h.AttachStorage(gate)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest("email=a@b.com&message=hi"))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (terminally handled, never retryable)", rec.Code)
+	}
+	var resp struct {
+		Status     string            `json:"status"`
+		Suppressed map[string]string `json:"suppressed"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != "suppressed" {
+		t.Errorf("status field = %q", resp.Status)
+	}
+	if resp.Suppressed["to@example.com"] != storage.ReasonHardBounce {
+		t.Errorf("suppressed map = %v", resp.Suppressed)
+	}
+	if len(tr.sent) != 0 {
+		t.Fatalf("suppressed submission sent mail (%d sends)", len(tr.sent))
+	}
+	// The submission log records the refusal.
+	subs, err := gate.Store().ListSubmissions(10)
+	if err != nil || len(subs) != 1 {
+		t.Fatalf("submissions = %d err=%v", len(subs), err)
+	}
+	if subs[0].Status != storage.StatusSuppressed {
+		t.Errorf("row status = %q", subs[0].Status)
+	}
+}
+
+func TestSuppression_Mixed_SendsRemainderReportsSuppressed(t *testing.T) {
+	tr := &recordingTransport{}
+	h := multiRecipientHandler(t, tr)
+	gate := newGate(t)
+	if err := gate.Store().AddSuppression("bounced@example.com", storage.ReasonSpamComplaint, "/x", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	h.AttachStorage(gate)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest("email=a@b.com&message=hi"))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if len(tr.sent) != 1 {
+		t.Fatalf("sends = %d", len(tr.sent))
+	}
+	if len(tr.sent[0].To) != 1 || tr.sent[0].To[0] != "clean@example.com" {
+		t.Errorf("sent To = %v, want only the clean recipient", tr.sent[0].To)
+	}
+	var resp struct {
+		Status     string            `json:"status"`
+		Suppressed map[string]string `json:"suppressed"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("status field = %q (mail did send)", resp.Status)
+	}
+	if resp.Suppressed["bounced@example.com"] != storage.ReasonSpamComplaint {
+		t.Errorf("suppressed map = %v", resp.Suppressed)
+	}
+}
+
+func TestSuppression_CaseInsensitiveAtSendTime(t *testing.T) {
+	tr := &recordingTransport{}
+	h := newTestHandler(t, tr) // recipient to@example.com
+	gate := newGate(t)
+	if err := gate.Store().AddSuppression("TO@EXAMPLE.COM", storage.ReasonManual, "", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	h.AttachStorage(gate)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest("email=a@b.com&message=hi"))
+	if len(tr.sent) != 0 {
+		t.Fatal("case-variant suppression dodged at send time")
+	}
+	_ = rec
+}
+
+func TestSuppression_NoStorage_V1Behavior(t *testing.T) {
+	tr := &recordingTransport{}
+	h := newTestHandler(t, tr) // no AttachStorage at all
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, urlencodedRequest("email=a@b.com&message=hi"))
+	if rec.Code != 200 || len(tr.sent) != 1 {
+		t.Fatalf("status=%d sends=%d", rec.Code, len(tr.sent))
+	}
+	// v1.x byte-shape: no suppressed key in the body.
+	var raw map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &raw)
+	if _, present := raw["suppressed"]; present {
+		t.Error("suppressed key present on storage-less deployment")
+	}
+}

--- a/core/lifecycle/forward.go
+++ b/core/lifecycle/forward.go
@@ -1,0 +1,202 @@
+package lifecycle
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/craigmccaskill/posthorn/storage"
+)
+
+// SignatureHeader carries the HMAC-SHA256 of the request body under the
+// endpoint's webhook_secret, hex-encoded with a scheme prefix:
+// "sha256=<hex>". Receivers recompute and constant-time compare (FR84).
+const SignatureHeader = "X-Posthorn-Signature"
+
+// forwardTimeout bounds one delivery attempt. Callback receivers are
+// operator-controlled servers; 5s matches the transport-side posture.
+const forwardTimeout = 5 * time.Second
+
+// Webhook is one endpoint's callback target (from config).
+type Webhook struct {
+	URL    string
+	Secret string
+}
+
+// Sign returns the SignatureHeader value for body under secret.
+func Sign(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// ForwardHooks observe delivery outcomes for metrics. outcome is a
+// fixed enum: "sent", "queued", "dropped".
+type ForwardHooks func(endpoint, outcome string)
+
+// Forwarder delivers normalized events to per-endpoint webhooks:
+// inline first, riding the storage forward-queue on transient failure
+// (FR84, same sync-first posture as mail).
+type Forwarder struct {
+	Webhooks map[string]Webhook // endpoint path → target
+	Gate     *storage.Gate
+	Logger   *slog.Logger
+	OnResult ForwardHooks // nil-safe
+
+	// Client is injectable for tests. Nil means a 5s-timeout default.
+	Client *http.Client
+
+	// Now is injectable for tests. Nil means time.Now.
+	Now func() time.Time
+}
+
+func (f *Forwarder) client() *http.Client {
+	if f.Client != nil {
+		return f.Client
+	}
+	return &http.Client{Timeout: forwardTimeout}
+}
+
+func (f *Forwarder) now() time.Time {
+	if f.Now != nil {
+		return f.Now()
+	}
+	return time.Now()
+}
+
+func (f *Forwarder) result(endpoint, outcome string) {
+	if f.OnResult != nil {
+		f.OnResult(endpoint, outcome)
+	}
+}
+
+// Deliver attempts one inline delivery for endpoint; transient failures
+// enqueue for background retry. A no-webhook endpoint is a silent no-op
+// (the caller filters, but defense in depth).
+func (f *Forwarder) Deliver(ctx context.Context, endpoint string, payload []byte) {
+	wh, ok := f.Webhooks[endpoint]
+	if !ok {
+		return
+	}
+	logger := f.Logger.With(slog.String("endpoint", endpoint))
+
+	retryable, err := f.attempt(ctx, wh, payload)
+	if err == nil {
+		logger.Info("lifecycle_forward_sent")
+		f.result(endpoint, "sent")
+		return
+	}
+	if retryable && f.Gate.Healthy() {
+		if qerr := f.Gate.Store().EnqueueForward(endpoint, payload, f.now()); qerr != nil {
+			f.Gate.ReportError(qerr)
+		} else {
+			logger.Warn("lifecycle_forward_queued", slog.String("error", err.Error()))
+			f.result(endpoint, "queued")
+			return
+		}
+	}
+	logger.Error("lifecycle_forward_dropped", slog.String("error", err.Error()))
+	f.result(endpoint, "dropped")
+}
+
+// attempt POSTs payload to the webhook. Classification mirrors FR19-22:
+// 2xx success; 429/5xx/network retryable; other 4xx terminal.
+//
+// NFR29: wh.Secret is used for signing only; it must never reach a log
+// or an error value.
+func (f *Forwarder) attempt(ctx context.Context, wh Webhook, payload []byte) (retryable bool, err error) {
+	ctx, cancel := context.WithTimeout(ctx, forwardTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wh.URL, bytes.NewReader(payload))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(SignatureHeader, Sign(payload, wh.Secret))
+
+	resp, err := f.client().Do(req)
+	if err != nil {
+		return true, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return false, nil
+	case resp.StatusCode == http.StatusTooManyRequests, resp.StatusCode >= 500:
+		return true, statusError(resp.StatusCode)
+	default:
+		return false, statusError(resp.StatusCode)
+	}
+}
+
+func statusError(code int) error {
+	return fmt.Errorf("webhook receiver returned status %d", code)
+}
+
+// RunQueue drains the forward queue until ctx is canceled — the
+// lifecycle counterpart of the mail retry worker, same jittered-poll
+// shape, one goroutine (NFR26).
+func (f *Forwarder) RunQueue(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+		f.ProcessDue(ctx)
+	}
+}
+
+// ProcessDue performs one poll of the forward queue. Exposed for
+// deterministic tests.
+func (f *Forwarder) ProcessDue(ctx context.Context) {
+	if !f.Gate.Healthy() {
+		return
+	}
+	due, err := f.Gate.Store().ClaimDueForwards(f.now(), 10)
+	if err != nil {
+		f.Logger.Error("lifecycle_queue_claim_failed", slog.String("error", err.Error()))
+		return
+	}
+	for _, p := range due {
+		if ctx.Err() != nil {
+			return
+		}
+		logger := f.Logger.With(slog.String("endpoint", p.Endpoint), slog.Int("attempt", p.Attempt))
+		wh, ok := f.Webhooks[p.Endpoint]
+		if !ok {
+			// Endpoint's webhook removed between restarts: drop.
+			_, _ = f.Gate.Store().RecordForwardOutcome(p.ID, false, f.now())
+			logger.Warn("lifecycle_forward_dropped", slog.String("error", "webhook no longer configured"))
+			f.result(p.Endpoint, "dropped")
+			continue
+		}
+		retryable, err := f.attempt(ctx, wh, p.Payload)
+		if err == nil {
+			_, _ = f.Gate.Store().RecordForwardOutcome(p.ID, false, f.now())
+			logger.Info("lifecycle_forward_sent")
+			f.result(p.Endpoint, "sent")
+			continue
+		}
+		dropped, oerr := f.Gate.Store().RecordForwardOutcome(p.ID, retryable, f.now())
+		if oerr != nil {
+			f.Gate.ReportError(oerr)
+			continue
+		}
+		if dropped || !retryable {
+			logger.Error("lifecycle_forward_dropped", slog.String("error", err.Error()))
+			f.result(p.Endpoint, "dropped")
+		} else {
+			logger.Warn("lifecycle_forward_retry_scheduled", slog.String("error", err.Error()))
+		}
+	}
+}

--- a/core/lifecycle/handler.go
+++ b/core/lifecycle/handler.go
@@ -1,0 +1,171 @@
+package lifecycle
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/craigmccaskill/posthorn/metrics"
+	"github.com/craigmccaskill/posthorn/ratelimit"
+	"github.com/craigmccaskill/posthorn/storage"
+)
+
+// maxEventBody bounds an inbound event payload. Postmark events are
+// single-digit KB; 256KB is generous headroom, not an invitation.
+const maxEventBody = 256 << 10
+
+// Threat posture for the ingestion endpoint (threat→defense table,
+// architecture doc): forged events poisoning the suppression list are
+// blocked by mandatory fail-closed basic auth; retry storms and
+// brute-force are blunted by the per-IP rate limit; oversized bodies by
+// MaxBytesReader; unknown message IDs are answered 200 so a
+// misconfigured (or probing) sender gets no retry loop and no oracle.
+type Handler struct {
+	username  string
+	password  string
+	gate      *storage.Gate
+	forwarder *Forwarder
+	logger    *slog.Logger
+	recorder  *metrics.Recorder
+	limiter   *ratelimit.Limiter
+
+	// now is injectable for tests. Production: time.Now.
+	now func() time.Time
+}
+
+// NewHandler builds the /events/postmark handler (FR82). username and
+// password are the mandatory basic-auth pair; forwarder carries the
+// per-endpoint webhook map and may deliver inline or via the queue.
+func NewHandler(username, password string, gate *storage.Gate, forwarder *Forwarder, logger *slog.Logger, recorder *metrics.Recorder) (*Handler, error) {
+	// 60 posts/min per source IP: far above any legitimate Postmark
+	// event rate for a self-hosted sender, low enough to blunt
+	// brute-force against the basic-auth pair.
+	limiter, err := ratelimit.New(60, time.Minute, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &Handler{
+		username:  username,
+		password:  password,
+		gate:      gate,
+		forwarder: forwarder,
+		logger:    logger,
+		recorder:  recorder,
+		limiter:   limiter,
+		now:       time.Now,
+	}, nil
+}
+
+// ServeHTTP implements the Postmark event sink (FR82, FR83, FR85).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ip := remoteIP(r)
+	if !h.limiter.Allow(ip) {
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	// Fail-closed basic auth, constant-time on both fields (NFR29).
+	user, pass, ok := r.BasicAuth()
+	userOK := subtle.ConstantTimeCompare([]byte(user), []byte(h.username))
+	passOK := subtle.ConstantTimeCompare([]byte(pass), []byte(h.password))
+	if !ok || userOK&passOK != 1 {
+		w.Header().Set("WWW-Authenticate", `Basic realm="posthorn-events"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxEventBody))
+	if err != nil {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// From here on the answer is 200 regardless of processing outcome:
+	// the sender is authenticated, and non-2xx answers only buy
+	// provider retry storms for events we will never process
+	// differently (FR83). Problems surface in logs and metrics.
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+
+	ev, messageID, err := NormalizePostmark(body, h.now())
+	if err != nil {
+		h.logger.Warn("lifecycle_event_malformed", slog.String("error", err.Error()))
+		h.recorder.LifecycleDropped("malformed")
+		return
+	}
+
+	if !h.gate.Healthy() {
+		// Degraded storage: no correlation possible. Drop loudly.
+		h.logger.Warn("lifecycle_event_dropped_storage_degraded", slog.String("event", ev.Event))
+		h.recorder.LifecycleDropped("unmatched")
+		return
+	}
+	sub, found, err := h.gate.Store().FindByMessageID(messageID)
+	if err != nil {
+		h.gate.ReportError(err)
+		h.recorder.LifecycleDropped("unmatched")
+		return
+	}
+	if !found {
+		h.logger.Info("lifecycle_event_unmatched",
+			slog.String("event", ev.Event),
+			slog.String("transport_message_id", messageID),
+		)
+		h.recorder.LifecycleDropped("unmatched")
+		return
+	}
+
+	ev.SubmissionID = sub.ID
+	ev.Endpoint = sub.Endpoint
+	h.recorder.LifecycleEvent(ev.Event)
+	h.logger.Info("lifecycle_event",
+		slog.String("event", ev.Event),
+		slog.String("submission_id", sub.ID),
+		slog.String("endpoint", sub.Endpoint),
+	)
+
+	// FR85: hard bounces and spam complaints auto-suppress globally.
+	if (ev.Event == EventHardBounce || ev.Event == EventSpamComplaint) && ev.Recipient != "" {
+		if err := h.gate.Store().AddSuppression(ev.Recipient, suppressionReason(ev.Event), sub.Endpoint, h.now()); err != nil {
+			h.gate.ReportError(err)
+		} else {
+			h.logger.Info("suppression_added",
+				slog.String("reason", suppressionReason(ev.Event)),
+				slog.String("endpoint", sub.Endpoint),
+			)
+		}
+	}
+
+	// FR84: forward to the originating endpoint's webhook, if any.
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		h.logger.Error("lifecycle_event_encode_failed", slog.String("error", err.Error()))
+		return
+	}
+	h.forwarder.Deliver(r.Context(), sub.Endpoint, payload)
+}
+
+func suppressionReason(event string) string {
+	if event == EventSpamComplaint {
+		return storage.ReasonSpamComplaint
+	}
+	return storage.ReasonHardBounce
+}
+
+func remoteIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/core/lifecycle/handler_test.go
+++ b/core/lifecycle/handler_test.go
@@ -1,0 +1,352 @@
+package lifecycle
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/craigmccaskill/posthorn/storage"
+)
+
+const (
+	testUser   = "pm-hook"
+	testPass   = "hook-password-sentinel"
+	testSecret = "webhook-secret-sentinel-16bytes"
+)
+
+// receiver captures forwarded callbacks for assertion.
+type receiver struct {
+	srv *httptest.Server
+
+	mu       sync.Mutex
+	bodies   [][]byte
+	sigs     []string
+	statuses []int // scripted responses; empty = always 200
+}
+
+func newReceiver(t *testing.T) *receiver {
+	t.Helper()
+	rc := &receiver{}
+	rc.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		rc.mu.Lock()
+		rc.bodies = append(rc.bodies, body)
+		rc.sigs = append(rc.sigs, r.Header.Get(SignatureHeader))
+		status := http.StatusOK
+		if len(rc.statuses) > 0 {
+			status = rc.statuses[0]
+			rc.statuses = rc.statuses[1:]
+		}
+		rc.mu.Unlock()
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(rc.srv.Close)
+	return rc
+}
+
+func (rc *receiver) received() ([][]byte, []string) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return append([][]byte(nil), rc.bodies...), append([]string(nil), rc.sigs...)
+}
+
+type fixture struct {
+	handler  *Handler
+	fwd      *Forwarder
+	gate     *storage.Gate
+	logs     *bytes.Buffer
+	outcomes []string
+	mu       sync.Mutex
+}
+
+func newFixture(t *testing.T, webhooks map[string]Webhook) *fixture {
+	t.Helper()
+	st, err := storage.Open(storage.Config{InMemory: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(logs, nil))
+	gate := storage.NewGate(st, logger)
+
+	fx := &fixture{gate: gate, logs: logs}
+	fx.fwd = &Forwarder{
+		Webhooks: webhooks,
+		Gate:     gate,
+		Logger:   logger,
+		Now:      func() time.Time { return t0 },
+		OnResult: func(endpoint, outcome string) {
+			fx.mu.Lock()
+			fx.outcomes = append(fx.outcomes, endpoint+":"+outcome)
+			fx.mu.Unlock()
+		},
+	}
+	h, err := NewHandler(testUser, testPass, gate, fx.fwd, logger, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.now = func() time.Time { return t0 }
+	fx.handler = h
+	return fx
+}
+
+// seedSubmission records a sent submission with the given message ID so
+// events can correlate.
+func (fx *fixture) seedSubmission(t *testing.T, id, endpoint, msgID string) {
+	t.Helper()
+	err := fx.gate.Store().RecordSubmission(storage.Submission{
+		ID: id, Endpoint: endpoint, Status: storage.StatusSending, CreatedAt: t0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fx.gate.Store().MarkSent(id, msgID, t0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func post(fx *fixture, body string, auth bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/events/postmark", strings.NewReader(body))
+	req.RemoteAddr = "203.0.113.7:44444"
+	if auth {
+		req.SetBasicAuth(testUser, testPass)
+	}
+	rec := httptest.NewRecorder()
+	fx.handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandler_RequiresAuth(t *testing.T) {
+	fx := newFixture(t, nil)
+	if rec := post(fx, `{"RecordType":"Delivery"}`, false); rec.Code != http.StatusUnauthorized {
+		t.Errorf("no-auth status = %d, want 401 (fail-closed)", rec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/events/postmark", strings.NewReader("{}"))
+	req.RemoteAddr = "203.0.113.7:44444"
+	req.SetBasicAuth(testUser, "wrong-password")
+	rec := httptest.NewRecorder()
+	fx.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("wrong-password status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	fx := newFixture(t, nil)
+	req := httptest.NewRequest(http.MethodGet, "/events/postmark", nil)
+	rec := httptest.NewRecorder()
+	fx.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d", rec.Code)
+	}
+}
+
+func TestHandler_UnmatchedEvent_200NoForward(t *testing.T) {
+	rc := newReceiver(t)
+	fx := newFixture(t, map[string]Webhook{"/contact": {URL: rc.srv.URL, Secret: testSecret}})
+
+	rec := post(fx, `{"RecordType":"Delivery","MessageID":"unknown-id","Recipient":"a@b.com"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no retry storms)", rec.Code)
+	}
+	if bodies, _ := rc.received(); len(bodies) != 0 {
+		t.Errorf("unmatched event forwarded %d times", len(bodies))
+	}
+	if !strings.Contains(fx.logs.String(), "lifecycle_event_unmatched") {
+		t.Error("unmatched drop not logged")
+	}
+}
+
+func TestHandler_MalformedBody_200Logged(t *testing.T) {
+	fx := newFixture(t, nil)
+	rec := post(fx, "not json at all", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(fx.logs.String(), "lifecycle_event_malformed") {
+		t.Error("malformed drop not logged")
+	}
+}
+
+func TestHandler_MatchedDelivery_ForwardsSignedNormalizedEvent(t *testing.T) {
+	rc := newReceiver(t)
+	fx := newFixture(t, map[string]Webhook{"/contact": {URL: rc.srv.URL, Secret: testSecret}})
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	rec := post(fx, `{"RecordType":"Delivery","MessageID":"pm-msg-1","Recipient":"a@b.com","DeliveredAt":"2026-08-02T10:00:00Z"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+
+	bodies, sigs := rc.received()
+	if len(bodies) != 1 {
+		t.Fatalf("forwards = %d", len(bodies))
+	}
+	var ev Event
+	if err := json.Unmarshal(bodies[0], &ev); err != nil {
+		t.Fatalf("forwarded body not an Event: %v", err)
+	}
+	if ev.Event != EventDelivered || ev.SubmissionID != "sub-1" || ev.Endpoint != "/contact" || ev.Recipient != "a@b.com" {
+		t.Errorf("event = %+v", ev)
+	}
+	if ev.Provider != "postmark" || len(ev.ProviderData) == 0 {
+		t.Errorf("provider fields = %q / %d bytes", ev.Provider, len(ev.ProviderData))
+	}
+	// FR84: signature verifies against the exact body bytes.
+	if !hmac.Equal([]byte(sigs[0]), []byte(Sign(bodies[0], testSecret))) {
+		t.Errorf("signature mismatch: %q", sigs[0])
+	}
+}
+
+func TestHandler_HardBounce_SuppressesAndForwards(t *testing.T) {
+	rc := newReceiver(t)
+	fx := newFixture(t, map[string]Webhook{"/contact": {URL: rc.srv.URL, Secret: testSecret}})
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	post(fx, `{"RecordType":"Bounce","Type":"HardBounce","MessageID":"pm-msg-1","Email":"Bounced@Example.com"}`, true)
+
+	sup, ok, err := fx.gate.Store().SuppressionFor("bounced@example.com")
+	if err != nil || !ok {
+		t.Fatalf("suppression missing: ok=%v err=%v", ok, err)
+	}
+	if sup.Reason != storage.ReasonHardBounce || sup.SourceEndpoint != "/contact" {
+		t.Errorf("suppression = %+v", sup)
+	}
+	if bodies, _ := rc.received(); len(bodies) != 1 {
+		t.Errorf("forwards = %d (suppression and callback both fire)", len(bodies))
+	}
+}
+
+func TestHandler_SpamComplaint_Suppresses(t *testing.T) {
+	fx := newFixture(t, nil)
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	post(fx, `{"RecordType":"SpamComplaint","MessageID":"pm-msg-1","Email":"c@example.com"}`, true)
+
+	sup, ok, _ := fx.gate.Store().SuppressionFor("c@example.com")
+	if !ok || sup.Reason != storage.ReasonSpamComplaint {
+		t.Fatalf("suppression = %+v ok=%v", sup, ok)
+	}
+}
+
+func TestHandler_SoftBounce_DoesNotSuppress(t *testing.T) {
+	fx := newFixture(t, nil)
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	post(fx, `{"RecordType":"Bounce","Type":"SoftBounce","MessageID":"pm-msg-1","Email":"s@example.com"}`, true)
+
+	if _, ok, _ := fx.gate.Store().SuppressionFor("s@example.com"); ok {
+		t.Fatal("soft bounce suppressed — only hard bounces and complaints may (FR85)")
+	}
+}
+
+func TestHandler_EndpointWithoutWebhook_ProcessesWithoutForward(t *testing.T) {
+	fx := newFixture(t, map[string]Webhook{"/other": {URL: "http://127.0.0.1:0", Secret: testSecret}})
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	rec := post(fx, `{"RecordType":"Bounce","Type":"HardBounce","MessageID":"pm-msg-1","Email":"x@example.com"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if _, ok, _ := fx.gate.Store().SuppressionFor("x@example.com"); !ok {
+		t.Fatal("suppression must not depend on a webhook being configured")
+	}
+}
+
+func TestForwarder_5xx_QueuesThenReplays(t *testing.T) {
+	rc := newReceiver(t)
+	rc.statuses = []int{503} // first attempt fails transiently
+	fx := newFixture(t, map[string]Webhook{"/contact": {URL: rc.srv.URL, Secret: testSecret}})
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	post(fx, `{"RecordType":"Delivery","MessageID":"pm-msg-1","Recipient":"a@b.com"}`, true)
+
+	fx.mu.Lock()
+	outcomes := append([]string(nil), fx.outcomes...)
+	fx.mu.Unlock()
+	if len(outcomes) != 1 || outcomes[0] != "/contact:queued" {
+		t.Fatalf("outcomes = %v", outcomes)
+	}
+
+	// Drive the queue worker past the first backoff; receiver now 200s.
+	fx.fwd.Now = func() time.Time { return t0.Add(storage.RetryBackoff[0] + time.Second) }
+	fx.fwd.ProcessDue(context.Background())
+
+	bodies, sigs := rc.received()
+	if len(bodies) != 2 {
+		t.Fatalf("attempts = %d, want 2 (inline + replay)", len(bodies))
+	}
+	if string(bodies[0]) != string(bodies[1]) {
+		t.Error("replayed payload differs from original")
+	}
+	if sigs[1] != Sign(bodies[1], testSecret) {
+		t.Error("replay signature invalid")
+	}
+}
+
+func TestForwarder_4xx_DroppedNotQueued(t *testing.T) {
+	rc := newReceiver(t)
+	rc.statuses = []int{400}
+	fx := newFixture(t, map[string]Webhook{"/contact": {URL: rc.srv.URL, Secret: testSecret}})
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	post(fx, `{"RecordType":"Delivery","MessageID":"pm-msg-1","Recipient":"a@b.com"}`, true)
+
+	fx.mu.Lock()
+	outcomes := append([]string(nil), fx.outcomes...)
+	fx.mu.Unlock()
+	if len(outcomes) != 1 || outcomes[0] != "/contact:dropped" {
+		t.Fatalf("outcomes = %v", outcomes)
+	}
+	if due, _ := fx.gate.Store().ClaimDueForwards(t0.Add(24*time.Hour), 10); len(due) != 0 {
+		t.Errorf("terminal failure queued: %d", len(due))
+	}
+}
+
+// NFR29: neither the webhook secret nor the basic-auth password may
+// appear in logs, even on failure paths.
+func TestLifecycle_SecretsNeverLogged(t *testing.T) {
+	rc := newReceiver(t)
+	rc.statuses = []int{500, 400}
+	fx := newFixture(t, map[string]Webhook{"/contact": {URL: rc.srv.URL, Secret: testSecret}})
+	fx.seedSubmission(t, "sub-1", "/contact", "pm-msg-1")
+
+	// Failure paths: auth failure, forward transient, forward terminal.
+	post(fx, "{}", false)
+	post(fx, `{"RecordType":"Delivery","MessageID":"pm-msg-1"}`, true)
+	post(fx, `{"RecordType":"Delivery","MessageID":"pm-msg-1"}`, true)
+
+	logged := fx.logs.String()
+	if strings.Contains(logged, testSecret) {
+		t.Error("webhook secret appeared in logs")
+	}
+	if strings.Contains(logged, testPass) {
+		t.Error("basic-auth password appeared in logs")
+	}
+}
+
+func TestHandler_RateLimit(t *testing.T) {
+	fx := newFixture(t, nil)
+	var got429 bool
+	for i := 0; i < 120; i++ {
+		if rec := post(fx, "not json", true); rec.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	if !got429 {
+		t.Error("no 429 across 120 rapid posts from one IP")
+	}
+}

--- a/core/lifecycle/lifecycle.go
+++ b/core/lifecycle/lifecycle.go
@@ -1,0 +1,148 @@
+// Package lifecycle ingests provider delivery events and forwards them
+// to the originating caller (FR82-FR85, ADR-22).
+//
+// v2.0 speaks one provider dialect — Postmark — behind a
+// provider-agnostic normalized event shape. The normalized fields are
+// the forward contract; the raw provider payload rides along as
+// explicitly best-effort provider_data. Additional providers slot in as
+// new normalizers behind the same shape.
+package lifecycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Event kinds (FR83). Label-safe operator-facing enum (NFR30) — never
+// derived from payload content outside this fixed set.
+const (
+	EventDelivered     = "delivered"
+	EventHardBounce    = "hard_bounce"
+	EventSoftBounce    = "soft_bounce"
+	EventSpamComplaint = "spam_complaint"
+	EventOpened        = "opened"
+	EventClicked       = "clicked"
+	EventOther         = "other"
+)
+
+// Event is the normalized shape (FR83) — both what Posthorn forwards to
+// webhook_url and the only contract consumers should couple to.
+type Event struct {
+	// Event is one of the Event* constants.
+	Event string `json:"event"`
+
+	// SubmissionID is Posthorn's submission UUID, correlated from the
+	// provider message ID via the submission log. The stable join key
+	// for callers who recorded submission IDs at send time.
+	SubmissionID string `json:"submission_id"`
+
+	// Endpoint is the originating endpoint path ("/contact",
+	// "smtp_listener").
+	Endpoint string `json:"endpoint"`
+
+	// Recipient is the affected address, when the provider names one.
+	Recipient string `json:"recipient,omitempty"`
+
+	// Timestamp is the provider's event time, best-effort; ingestion
+	// time when the provider omits or mangles it.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Provider names the source dialect ("postmark").
+	Provider string `json:"provider"`
+
+	// ProviderData is the raw provider payload, passed through
+	// best-effort. Consumers coupling to it are on their own (ADR-22);
+	// the normalized fields above are the API.
+	ProviderData json.RawMessage `json:"provider_data,omitempty"`
+}
+
+// postmarkEvent captures the fields Posthorn reads from Postmark's
+// webhook payloads. Postmark spreads the recipient and timestamp across
+// differently-named fields per RecordType; all candidates are listed
+// and coalesced.
+type postmarkEvent struct {
+	RecordType string `json:"RecordType"`
+	Type       string `json:"Type"` // bounce subtype (HardBounce, SoftBounce, Transient, ...)
+	MessageID  string `json:"MessageID"`
+
+	Email     string `json:"Email"`     // Bounce, SpamComplaint
+	Recipient string `json:"Recipient"` // Delivery, Open, Click
+
+	DeliveredAt string `json:"DeliveredAt"`
+	BouncedAt   string `json:"BouncedAt"`
+	ReceivedAt  string `json:"ReceivedAt"`
+}
+
+// hardBounceTypes are the Postmark bounce subtypes that indicate the
+// mailbox is durably undeliverable — the FR85 auto-suppress set.
+// Everything else bounce-shaped (SoftBounce, Transient, DnsError, ...)
+// normalizes to soft_bounce and does not suppress.
+var hardBounceTypes = map[string]bool{
+	"HardBounce":          true,
+	"BadEmailAddress":     true,
+	"ManuallyDeactivated": true,
+}
+
+// NormalizePostmark parses a Postmark webhook body into the normalized
+// shape (FR83). The provider MessageID is returned separately for
+// submission-log correlation. Unknown RecordTypes normalize to "other"
+// rather than erroring — Postmark adding event types must not break
+// ingestion.
+func NormalizePostmark(body []byte, now time.Time) (ev Event, messageID string, err error) {
+	var pe postmarkEvent
+	if err := json.Unmarshal(body, &pe); err != nil {
+		return Event{}, "", fmt.Errorf("lifecycle: parse postmark payload: %w", err)
+	}
+	if pe.RecordType == "" {
+		return Event{}, "", fmt.Errorf("lifecycle: postmark payload has no RecordType")
+	}
+
+	kind := EventOther
+	recipient := pe.Recipient
+	ts := pe.ReceivedAt
+	switch pe.RecordType {
+	case "Delivery":
+		kind = EventDelivered
+		ts = firstNonEmpty(pe.DeliveredAt, ts)
+	case "Bounce":
+		kind = EventSoftBounce
+		if hardBounceTypes[pe.Type] {
+			kind = EventHardBounce
+		}
+		recipient = firstNonEmpty(pe.Email, recipient)
+		ts = firstNonEmpty(pe.BouncedAt, ts)
+	case "SpamComplaint":
+		kind = EventSpamComplaint
+		recipient = firstNonEmpty(pe.Email, recipient)
+		ts = firstNonEmpty(pe.BouncedAt, ts)
+	case "Open":
+		kind = EventOpened
+	case "Click":
+		kind = EventClicked
+	}
+
+	when := now
+	if ts != "" {
+		if parsed, perr := time.Parse(time.RFC3339, ts); perr == nil {
+			when = parsed
+		}
+	}
+
+	return Event{
+		Event:        kind,
+		Recipient:    recipient,
+		Timestamp:    when.UTC(),
+		Provider:     "postmark",
+		ProviderData: json.RawMessage(body),
+	}, pe.MessageID, nil
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/core/lifecycle/lifecycle_test.go
+++ b/core/lifecycle/lifecycle_test.go
@@ -1,0 +1,154 @@
+package lifecycle
+
+import (
+	"testing"
+	"time"
+)
+
+var t0 = time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+
+func TestNormalizePostmark_Table(t *testing.T) {
+	cases := []struct {
+		name          string
+		body          string
+		wantEvent     string
+		wantRecipient string
+		wantMessageID string
+	}{
+		{
+			name:          "delivery",
+			body:          `{"RecordType":"Delivery","MessageID":"pm-1","Recipient":"a@example.com","DeliveredAt":"2026-08-02T10:00:00Z"}`,
+			wantEvent:     EventDelivered,
+			wantRecipient: "a@example.com",
+			wantMessageID: "pm-1",
+		},
+		{
+			name:          "hard bounce",
+			body:          `{"RecordType":"Bounce","Type":"HardBounce","MessageID":"pm-2","Email":"b@example.com","BouncedAt":"2026-08-02T10:00:00Z"}`,
+			wantEvent:     EventHardBounce,
+			wantRecipient: "b@example.com",
+			wantMessageID: "pm-2",
+		},
+		{
+			name:          "bad address is a hard bounce",
+			body:          `{"RecordType":"Bounce","Type":"BadEmailAddress","MessageID":"pm-3","Email":"c@example.com"}`,
+			wantEvent:     EventHardBounce,
+			wantRecipient: "c@example.com",
+			wantMessageID: "pm-3",
+		},
+		{
+			name:          "soft bounce",
+			body:          `{"RecordType":"Bounce","Type":"SoftBounce","MessageID":"pm-4","Email":"d@example.com"}`,
+			wantEvent:     EventSoftBounce,
+			wantRecipient: "d@example.com",
+			wantMessageID: "pm-4",
+		},
+		{
+			name:          "transient bounce is soft",
+			body:          `{"RecordType":"Bounce","Type":"Transient","MessageID":"pm-5","Email":"e@example.com"}`,
+			wantEvent:     EventSoftBounce,
+			wantRecipient: "e@example.com",
+			wantMessageID: "pm-5",
+		},
+		{
+			name:          "spam complaint",
+			body:          `{"RecordType":"SpamComplaint","MessageID":"pm-6","Email":"f@example.com"}`,
+			wantEvent:     EventSpamComplaint,
+			wantRecipient: "f@example.com",
+			wantMessageID: "pm-6",
+		},
+		{
+			name:          "open",
+			body:          `{"RecordType":"Open","MessageID":"pm-7","Recipient":"g@example.com"}`,
+			wantEvent:     EventOpened,
+			wantRecipient: "g@example.com",
+			wantMessageID: "pm-7",
+		},
+		{
+			name:          "click",
+			body:          `{"RecordType":"Click","MessageID":"pm-8","Recipient":"h@example.com"}`,
+			wantEvent:     EventClicked,
+			wantRecipient: "h@example.com",
+			wantMessageID: "pm-8",
+		},
+		{
+			name:          "unknown record type normalizes to other",
+			body:          `{"RecordType":"SubscriptionChange","MessageID":"pm-9"}`,
+			wantEvent:     EventOther,
+			wantMessageID: "pm-9",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, msgID, err := NormalizePostmark([]byte(tc.body), t0)
+			if err != nil {
+				t.Fatalf("NormalizePostmark: %v", err)
+			}
+			if ev.Event != tc.wantEvent {
+				t.Errorf("Event = %q, want %q", ev.Event, tc.wantEvent)
+			}
+			if ev.Recipient != tc.wantRecipient {
+				t.Errorf("Recipient = %q, want %q", ev.Recipient, tc.wantRecipient)
+			}
+			if msgID != tc.wantMessageID {
+				t.Errorf("messageID = %q, want %q", msgID, tc.wantMessageID)
+			}
+			if ev.Provider != "postmark" {
+				t.Errorf("Provider = %q", ev.Provider)
+			}
+			if string(ev.ProviderData) != tc.body {
+				t.Errorf("ProviderData should carry the raw payload")
+			}
+		})
+	}
+}
+
+func TestNormalizePostmark_ProviderTimestampWins(t *testing.T) {
+	ev, _, err := NormalizePostmark(
+		[]byte(`{"RecordType":"Delivery","MessageID":"m","DeliveredAt":"2026-07-01T08:30:00Z"}`), t0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 7, 1, 8, 30, 0, 0, time.UTC)
+	if !ev.Timestamp.Equal(want) {
+		t.Errorf("Timestamp = %v, want %v", ev.Timestamp, want)
+	}
+}
+
+func TestNormalizePostmark_BadTimestampFallsBackToNow(t *testing.T) {
+	ev, _, err := NormalizePostmark(
+		[]byte(`{"RecordType":"Delivery","MessageID":"m","DeliveredAt":"not-a-time"}`), t0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ev.Timestamp.Equal(t0) {
+		t.Errorf("Timestamp = %v, want ingestion time %v", ev.Timestamp, t0)
+	}
+}
+
+func TestNormalizePostmark_Malformed(t *testing.T) {
+	for _, body := range []string{"not json", "{}", `{"MessageID":"m"}`} {
+		if _, _, err := NormalizePostmark([]byte(body), t0); err == nil {
+			t.Errorf("NormalizePostmark(%q): expected error", body)
+		}
+	}
+}
+
+func TestSign_KnownVector(t *testing.T) {
+	// Deterministic: receivers implementing verification against the
+	// docs must produce exactly this.
+	got := Sign([]byte(`{"event":"delivered"}`), "test-secret-16by")
+	if len(got) != len("sha256=")+64 {
+		t.Fatalf("signature shape: %q", got)
+	}
+	if got[:7] != "sha256=" {
+		t.Fatalf("missing scheme prefix: %q", got)
+	}
+	// Same body+secret → same signature; different secret → different.
+	if Sign([]byte(`{"event":"delivered"}`), "test-secret-16by") != got {
+		t.Error("signature not deterministic")
+	}
+	if Sign([]byte(`{"event":"delivered"}`), "other-secret-16b") == got {
+		t.Error("signature ignores the secret")
+	}
+}

--- a/core/metrics/recorder.go
+++ b/core/metrics/recorder.go
@@ -36,6 +36,13 @@ type Recorder struct {
 	queueDeadLetter  *Counter
 	storageHealthy   *Gauge
 	retryQueueDepth  *Gauge
+
+	// v2.0 lifecycle + suppression surface (FR82-FR86). Label values
+	// are fixed enums / endpoint paths only (NFR30).
+	suppressed        *Counter
+	lifecycleEvents   *Counter
+	lifecycleDropped  *Counter
+	lifecycleForwards *Counter
 }
 
 // NewRecorder constructs a Recorder backed by counters and histograms
@@ -123,6 +130,26 @@ func NewRecorder(reg *Registry) *Recorder {
 			"Submissions currently waiting in (or claimed from) the retry queue.",
 			nil,
 		),
+		suppressed: NewCounter(
+			"posthorn_suppressed_recipients_total",
+			"Recipients removed from sends by the suppression list (FR86).",
+			[]string{"endpoint"},
+		),
+		lifecycleEvents: NewCounter(
+			"posthorn_lifecycle_events_total",
+			"Provider lifecycle events accepted and normalized. event is the fixed normalized enum.",
+			[]string{"event"},
+		),
+		lifecycleDropped: NewCounter(
+			"posthorn_lifecycle_dropped_total",
+			"Inbound lifecycle posts dropped without processing. reason is \"unmatched\" (no submission for the message ID) or \"malformed\".",
+			[]string{"reason"},
+		),
+		lifecycleForwards: NewCounter(
+			"posthorn_lifecycle_forwards_total",
+			"Callback forwarding outcomes per originating endpoint. outcome is \"sent\", \"queued\", or \"dropped\".",
+			[]string{"endpoint", "outcome"},
+		),
 	}
 	reg.Register(r.submitted)
 	reg.Register(r.sent)
@@ -140,6 +167,10 @@ func NewRecorder(reg *Registry) *Recorder {
 	reg.Register(r.queueDeadLetter)
 	reg.Register(r.storageHealthy)
 	reg.Register(r.retryQueueDepth)
+	reg.Register(r.suppressed)
+	reg.Register(r.lifecycleEvents)
+	reg.Register(r.lifecycleDropped)
+	reg.Register(r.lifecycleForwards)
 	return r
 }
 
@@ -278,4 +309,40 @@ func (r *Recorder) SetQueueDepth(n int) {
 		return
 	}
 	r.retryQueueDepth.Set(float64(n))
+}
+
+// Suppressed records recipients removed from a send by the suppression
+// list (FR86). n is the number of removed recipients.
+func (r *Recorder) Suppressed(endpoint string, n int) {
+	if r == nil || n <= 0 {
+		return
+	}
+	r.suppressed.Add(int64(n), endpoint)
+}
+
+// LifecycleEvent records one accepted, normalized provider event. kind
+// must be a lifecycle.Event* enum value (NFR30).
+func (r *Recorder) LifecycleEvent(kind string) {
+	if r == nil {
+		return
+	}
+	r.lifecycleEvents.Inc(kind)
+}
+
+// LifecycleDropped records an inbound event post dropped without
+// processing. reason is "unmatched" or "malformed".
+func (r *Recorder) LifecycleDropped(reason string) {
+	if r == nil {
+		return
+	}
+	r.lifecycleDropped.Inc(reason)
+}
+
+// LifecycleForward records a callback delivery outcome ("sent",
+// "queued", "dropped").
+func (r *Recorder) LifecycleForward(endpoint, outcome string) {
+	if r == nil {
+		return
+	}
+	r.lifecycleForwards.Inc(endpoint, outcome)
 }

--- a/core/response/response.go
+++ b/core/response/response.go
@@ -36,6 +36,15 @@ type Error struct {
 type Success struct {
 	Status       string `json:"status"`
 	SubmissionID string `json:"submission_id"`
+
+	// Suppressed lists recipients removed from this send by the
+	// suppression list, keyed by address with the suppression reason as
+	// the value (FR86, v2.0). Empty on sends with no suppressed
+	// recipients — including every send on a storage-less deployment —
+	// so v1.x response bodies are byte-identical. When Status is
+	// "suppressed", every recipient was on the list and nothing was
+	// sent; 2xx still means terminally handled — do not retry.
+	Suppressed map[string]string `json:"suppressed,omitempty"`
 }
 
 // DryRun is the JSON envelope returned on 200 when the endpoint has

--- a/core/smtp/session.go
+++ b/core/smtp/session.go
@@ -404,6 +404,25 @@ func (s *session) handleDATA() {
 	defer cancel()
 	submissionID := uuid.NewString()
 
+	// FR86: drop suppressed recipients before the send. All suppressed
+	// → 250 (terminally handled; a 5xx would make the client retry mail
+	// that must never send) with nothing delivered.
+	var suppressedCount int
+	msg.To, suppressedCount = s.filterSuppressed(msg.To)
+	if suppressedCount > 0 && s.l.recorder != nil {
+		s.l.recorder.Suppressed(smtpEndpointLabel, suppressedCount)
+	}
+	if len(msg.To) == 0 {
+		s.recordSuppressed(submissionID, msg)
+		_ = s.writeReply(250, "2.1.5 OK suppressed as "+submissionID)
+		s.logger.Info("smtp_submission_suppressed",
+			slog.String("submission_id", submissionID),
+			slog.Int("recipients", suppressedCount),
+		)
+		s.resetTransaction()
+		return
+	}
+
 	// FR77: persist pre-send (status "sending") so a crash mid-send is
 	// recoverable (NFR28). Best-effort; degraded storage never blocks.
 	persisted, queueable := s.recordSubmission(submissionID, msg)
@@ -497,6 +516,51 @@ func (s *session) recordSubmission(id string, msg transport.Message) (persisted,
 // submission log — the SMTP listener has no HTTP path. Matches the
 // constant in cmd/posthorn's worker transport map.
 const smtpEndpointLabel = "smtp_listener"
+
+// filterSuppressed drops suppressed recipients (FR86). Without storage
+// (or degraded) everything passes — v1.x untouched; lookup errors fail
+// open per-recipient (mail first, NFR27).
+func (s *session) filterSuppressed(to []string) (remaining []string, suppressed int) {
+	g := s.l.gate
+	if g == nil || !g.Healthy() {
+		return to, 0
+	}
+	remaining = make([]string, 0, len(to))
+	for _, addr := range to {
+		_, ok, err := g.Store().SuppressionFor(addr)
+		if err != nil {
+			g.ReportError(err)
+			remaining = append(remaining, addr)
+			continue
+		}
+		if ok {
+			suppressed++
+			continue
+		}
+		remaining = append(remaining, addr)
+	}
+	return remaining, suppressed
+}
+
+// recordSuppressed logs an all-recipients-suppressed submission.
+func (s *session) recordSuppressed(id string, msg transport.Message) {
+	g := s.l.gate
+	if g == nil || !g.Healthy() {
+		return
+	}
+	err := g.Store().RecordSubmission(storage.Submission{
+		ID:        id,
+		Endpoint:  smtpEndpointLabel,
+		Transport: s.l.cfg.Transport.Type,
+		From:      msg.From,
+		Subject:   msg.Subject,
+		Status:    storage.StatusSuppressed,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		g.ReportError(err)
+	}
+}
 
 func (s *session) recordSendOk(latency time.Duration) {
 	if s.l.recorder == nil {

--- a/core/smtp/storage_test.go
+++ b/core/smtp/storage_test.go
@@ -132,6 +132,63 @@ func TestSMTP_Storage_TerminalFailure_451AndFailedRow(t *testing.T) {
 	}
 }
 
+func TestSMTP_Suppression_AllSuppressed_250NoSend(t *testing.T) {
+	f := startListener(t, baseTestConfig())
+	gate := attachTestGate(t, f)
+	if err := gate.Store().AddSuppression("alice@somewhere.com", storage.ReasonHardBounce, "/x", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	code, msg := deliverBasic(t, f)
+	if code != 250 {
+		t.Fatalf("DATA reply = %d %q — suppressed mail answers 250 so the client never retries", code, msg)
+	}
+	if !strings.Contains(msg, "suppressed") {
+		t.Errorf("reply = %q", msg)
+	}
+	if got := f.mt.Sent(); len(got) != 0 {
+		t.Fatalf("suppressed submission sent mail: %d", len(got))
+	}
+	subs, _ := gate.Store().ListSubmissions(10)
+	if len(subs) != 1 || subs[0].Status != storage.StatusSuppressed {
+		t.Fatalf("row = %+v", subs)
+	}
+}
+
+func TestSMTP_Suppression_Mixed_SendsRemainder(t *testing.T) {
+	f := startListener(t, baseTestConfig())
+	gate := attachTestGate(t, f)
+	if err := gate.Store().AddSuppression("bounced@somewhere.com", storage.ReasonSpamComplaint, "/x", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	tp := f.dial()
+	_ = tp.PrintfLine("EHLO client.test")
+	expectMultiline(t, tp, 250)
+	_ = tp.PrintfLine("AUTH PLAIN %s", authPlainCreds("user", "pass"))
+	expect(t, tp, 235)
+	_ = tp.PrintfLine("MAIL FROM:<noreply@example.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("RCPT TO:<alice@somewhere.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("RCPT TO:<bounced@somewhere.com>")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("DATA")
+	expect(t, tp, 354)
+	_ = tp.PrintfLine("From: noreply@example.com\r\nSubject: Hello\r\n\r\nBody text.\r\n.")
+	expect(t, tp, 250)
+	_ = tp.PrintfLine("QUIT")
+
+	waitForSend(t, f.mt, 1, 500*time.Millisecond)
+	sent := f.mt.Sent()
+	if len(sent) != 1 {
+		t.Fatalf("sends = %d", len(sent))
+	}
+	if len(sent[0].To) != 1 || sent[0].To[0] != "alice@somewhere.com" {
+		t.Errorf("To = %v, want only the clean recipient", sent[0].To)
+	}
+}
+
 func TestSMTP_Storage_Degraded_V1Behavior(t *testing.T) {
 	shortRetryDelays(t)
 	f := startListener(t, baseTestConfig())

--- a/core/storage/forwardqueue.go
+++ b/core/storage/forwardqueue.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Forward queue for lifecycle-event callbacks (FR84). Same sync-first
+// posture as the mail queue: the inline forward attempt happens in the
+// event handler; only transient/rate-limited failures land here, and
+// the forwarder worker replays them on the shared RetryBackoff ladder.
+//
+// Unlike mail, an event that exhausts its ladder is deleted (with a
+// log), not dead-lettered to a table — events are telemetry about mail,
+// not mail; the submission log still holds the underlying truth.
+
+// PendingForward is one queued callback delivery. Payload is the exact
+// normalized-event JSON to POST; the webhook URL and secret are
+// resolved from config at send time so secrets never persist (NFR29).
+type PendingForward struct {
+	ID       int64
+	Endpoint string
+	Payload  []byte
+	Attempt  int
+}
+
+// EnqueueForward stores a callback for background retry, due after the
+// first backoff step.
+func (s *Store) EnqueueForward(endpoint string, payload []byte, now time.Time) error {
+	_, err := s.db.Exec(`
+		INSERT INTO lifecycle_queue (endpoint, payload, attempt, next_attempt_at)
+		VALUES (?, ?, 0, ?)`,
+		endpoint, payload, now.Add(RetryBackoff[0]).Unix())
+	if err != nil {
+		return fmt.Errorf("storage: enqueue forward: %w", err)
+	}
+	return nil
+}
+
+// ClaimDueForwards returns up to limit due callbacks. Rows stay in the
+// table until RecordForwardOutcome removes or reschedules them, so a
+// crash mid-forward re-delivers (at-least-once, same as mail).
+func (s *Store) ClaimDueForwards(now time.Time, limit int) ([]PendingForward, error) {
+	rows, err := s.db.Query(`
+		SELECT id, endpoint, payload, attempt FROM lifecycle_queue
+		WHERE next_attempt_at <= ?
+		ORDER BY next_attempt_at LIMIT ?`, now.Unix(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: claim forwards: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []PendingForward
+	for rows.Next() {
+		var p PendingForward
+		if err := rows.Scan(&p.ID, &p.Endpoint, &p.Payload, &p.Attempt); err != nil {
+			return nil, fmt.Errorf("storage: claim forwards: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// RecordForwardOutcome finalizes an attempt: success or terminal
+// failure removes the row; a retryable failure bumps the attempt and
+// reschedules, deleting (dropped=true) once the ladder is exhausted.
+func (s *Store) RecordForwardOutcome(id int64, retryable bool, now time.Time) (dropped bool, err error) {
+	if !retryable {
+		_, err := s.db.Exec(`DELETE FROM lifecycle_queue WHERE id = ?`, id)
+		if err != nil {
+			return false, fmt.Errorf("storage: forward outcome: %w", err)
+		}
+		return false, nil
+	}
+	var attempt int
+	err = s.db.QueryRow(`SELECT attempt FROM lifecycle_queue WHERE id = ?`, id).Scan(&attempt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("storage: forward outcome: %w", err)
+	}
+	attempt++
+	if attempt >= MaxAttempts {
+		if _, err := s.db.Exec(`DELETE FROM lifecycle_queue WHERE id = ?`, id); err != nil {
+			return false, fmt.Errorf("storage: forward outcome: %w", err)
+		}
+		return true, nil
+	}
+	_, err = s.db.Exec(`
+		UPDATE lifecycle_queue SET attempt = ?, next_attempt_at = ? WHERE id = ?`,
+		attempt, now.Add(RetryBackoff[attempt]).Unix(), id)
+	if err != nil {
+		return false, fmt.Errorf("storage: forward outcome: %w", err)
+	}
+	return false, nil
+}

--- a/core/storage/storage.go
+++ b/core/storage/storage.go
@@ -215,6 +215,15 @@ CREATE TABLE IF NOT EXISTS canary (
   id INTEGER PRIMARY KEY CHECK (id = 1),
   at INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS lifecycle_queue (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  endpoint        TEXT NOT NULL,
+  payload         BLOB NOT NULL,
+  attempt         INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_lifecycle_due ON lifecycle_queue(next_attempt_at);
 `
 
 // recoverInFlight moves crash-window rows ("sending" at open) into the

--- a/core/storage/suppression.go
+++ b/core/storage/suppression.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Suppression reasons (ADR-23). Bounce and complaint rows are written
+// by the lifecycle ingester (FR85); manual rows come from the
+// `posthorn suppressions` CLI (FR87). All shipped reasons are global —
+// per-endpoint scoping is reserved for future unsubscribe-class
+// reasons.
+const (
+	ReasonHardBounce    = "hard_bounce"
+	ReasonSpamComplaint = "spam_complaint"
+	ReasonManual        = "manual"
+)
+
+// Suppression is one row of the suppression list. Rows are exempt from
+// retention pruning by design: forgetting a bounce defeats the feature
+// (ADR-23). Erasure is the CLI's remove command.
+type Suppression struct {
+	Email          string
+	Reason         string
+	SourceEndpoint string
+	CreatedAt      time.Time
+}
+
+// normalizeEmail lower-cases for storage and lookup — suppression must
+// not be dodged by case variance.
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// AddSuppression inserts a row. Idempotent per (email, reason): the
+// first observation wins and keeps its timestamp.
+func (s *Store) AddSuppression(email, reason, sourceEndpoint string, at time.Time) error {
+	email = normalizeEmail(email)
+	if email == "" {
+		return fmt.Errorf("storage: suppression email is empty")
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO suppressions (email, reason, source_endpoint, created_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(email, reason) DO NOTHING`,
+		email, reason, sourceEndpoint, at.Unix())
+	if err != nil {
+		return fmt.Errorf("storage: add suppression: %w", err)
+	}
+	return nil
+}
+
+// SuppressionFor reports whether email is suppressed under any reason
+// (all shipped reasons are global). With multiple rows the earliest wins
+// for reporting.
+func (s *Store) SuppressionFor(email string) (Suppression, bool, error) {
+	row := s.db.QueryRow(`
+		SELECT email, reason, source_endpoint, created_at
+		FROM suppressions WHERE email = ?
+		ORDER BY created_at, reason LIMIT 1`, normalizeEmail(email))
+	var sup Suppression
+	var createdAt int64
+	err := row.Scan(&sup.Email, &sup.Reason, &sup.SourceEndpoint, &createdAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Suppression{}, false, nil
+		}
+		return Suppression{}, false, fmt.Errorf("storage: suppression lookup: %w", err)
+	}
+	sup.CreatedAt = time.Unix(createdAt, 0).UTC()
+	return sup, true, nil
+}
+
+// RemoveSuppression deletes every reason-row for email (the CLI's
+// remove / GDPR-erasure path, FR87). Returns rows removed.
+func (s *Store) RemoveSuppression(email string) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM suppressions WHERE email = ?`, normalizeEmail(email))
+	if err != nil {
+		return 0, fmt.Errorf("storage: remove suppression: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// ListSuppressions returns rows ordered oldest-first, up to limit.
+func (s *Store) ListSuppressions(limit int) ([]Suppression, error) {
+	rows, err := s.db.Query(`
+		SELECT email, reason, source_endpoint, created_at
+		FROM suppressions ORDER BY created_at, email LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list suppressions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Suppression
+	for rows.Next() {
+		var sup Suppression
+		var createdAt int64
+		if err := rows.Scan(&sup.Email, &sup.Reason, &sup.SourceEndpoint, &createdAt); err != nil {
+			return nil, fmt.Errorf("storage: list suppressions: %w", err)
+		}
+		sup.CreatedAt = time.Unix(createdAt, 0).UTC()
+		out = append(out, sup)
+	}
+	return out, rows.Err()
+}

--- a/core/storage/suppression_test.go
+++ b/core/storage/suppression_test.go
@@ -1,0 +1,138 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSuppression_AddLookupRemove(t *testing.T) {
+	s := memStore(t)
+	if err := s.AddSuppression("Bounced@Example.COM", ReasonHardBounce, "/contact", t0); err != nil {
+		t.Fatalf("AddSuppression: %v", err)
+	}
+
+	// Lookup is case-insensitive both directions.
+	sup, ok, err := s.SuppressionFor("bounced@example.com")
+	if err != nil || !ok {
+		t.Fatalf("SuppressionFor: ok=%v err=%v", ok, err)
+	}
+	if sup.Reason != ReasonHardBounce || sup.SourceEndpoint != "/contact" {
+		t.Errorf("sup = %+v", sup)
+	}
+	if _, ok, _ := s.SuppressionFor("BOUNCED@example.com"); !ok {
+		t.Error("case-variant lookup missed")
+	}
+	if _, ok, _ := s.SuppressionFor("clean@example.com"); ok {
+		t.Error("clean address reported suppressed")
+	}
+
+	n, err := s.RemoveSuppression("BOUNCED@EXAMPLE.COM")
+	if err != nil || n != 1 {
+		t.Fatalf("RemoveSuppression: n=%d err=%v", n, err)
+	}
+	if _, ok, _ := s.SuppressionFor("bounced@example.com"); ok {
+		t.Error("still suppressed after remove")
+	}
+}
+
+func TestSuppression_IdempotentPerReason_RemoveClearsAll(t *testing.T) {
+	s := memStore(t)
+	if err := s.AddSuppression("x@example.com", ReasonHardBounce, "/a", t0); err != nil {
+		t.Fatal(err)
+	}
+	// Same (email, reason) again: first observation wins, no error.
+	if err := s.AddSuppression("x@example.com", ReasonHardBounce, "/b", t0.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	// A second reason coexists.
+	if err := s.AddSuppression("x@example.com", ReasonSpamComplaint, "/a", t0.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := s.ListSuppressions(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("rows = %d, want 2", len(list))
+	}
+	if list[0].SourceEndpoint != "/a" || !list[0].CreatedAt.Equal(t0) {
+		t.Errorf("first row lost first-observation data: %+v", list[0])
+	}
+
+	n, _ := s.RemoveSuppression("x@example.com")
+	if n != 2 {
+		t.Errorf("remove cleared %d rows, want 2 (all reasons)", n)
+	}
+}
+
+func TestSuppression_ExemptFromPrune(t *testing.T) {
+	s := memStore(t)
+	old := t0.Add(-400 * 24 * time.Hour)
+	if err := s.AddSuppression("x@example.com", ReasonHardBounce, "/a", old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Prune(t0); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.SuppressionFor("x@example.com"); !ok {
+		t.Fatal("suppression pruned — rows must be retention-exempt (ADR-23)")
+	}
+}
+
+func TestForwardQueue_LadderAndDrop(t *testing.T) {
+	s := memStore(t)
+	payload := []byte(`{"event":"delivered"}`)
+	if err := s.EnqueueForward("/contact", payload, t0); err != nil {
+		t.Fatalf("EnqueueForward: %v", err)
+	}
+
+	// Not due before the first backoff.
+	if due, _ := s.ClaimDueForwards(t0.Add(RetryBackoff[0]-time.Second), 10); len(due) != 0 {
+		t.Fatalf("due early: %d", len(due))
+	}
+	due, err := s.ClaimDueForwards(t0.Add(RetryBackoff[0]+time.Second), 10)
+	if err != nil || len(due) != 1 {
+		t.Fatalf("due = %d err=%v", len(due), err)
+	}
+	if string(due[0].Payload) != string(payload) || due[0].Endpoint != "/contact" {
+		t.Errorf("claimed = %+v", due[0])
+	}
+
+	// Ladder through retryable failures until dropped.
+	id := due[0].ID
+	var droppedAt int
+	for i := 1; i <= MaxAttempts; i++ {
+		dropped, err := s.RecordForwardOutcome(id, true, t0)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", i, err)
+		}
+		if dropped {
+			droppedAt = i
+			break
+		}
+	}
+	if droppedAt != MaxAttempts {
+		t.Fatalf("dropped at attempt %d, want %d", droppedAt, MaxAttempts)
+	}
+	if due, _ := s.ClaimDueForwards(t0.Add(365*24*time.Hour), 10); len(due) != 0 {
+		t.Errorf("row survived drop: %d", len(due))
+	}
+}
+
+func TestForwardQueue_SuccessRemoves(t *testing.T) {
+	s := memStore(t)
+	if err := s.EnqueueForward("/contact", []byte("{}"), t0); err != nil {
+		t.Fatal(err)
+	}
+	due, _ := s.ClaimDueForwards(t0.Add(time.Hour), 10)
+	if len(due) != 1 {
+		t.Fatal("nothing due")
+	}
+	if _, err := s.RecordForwardOutcome(due[0].ID, false, t0); err != nil {
+		t.Fatal(err)
+	}
+	if due, _ := s.ClaimDueForwards(t0.Add(365*24*time.Hour), 10); len(due) != 0 {
+		t.Errorf("row survived success: %d", len(due))
+	}
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -87,6 +87,8 @@ export default defineConfig({
             { label: 'Validation', slug: 'features/validation' },
             { label: 'Templating', slug: 'features/templating' },
             { label: 'HTML email bodies', slug: 'features/html-body' },
+            { label: 'Storage & reliability', slug: 'features/storage' },
+            { label: 'Lifecycle events & suppression', slug: 'features/lifecycle' },
             { label: 'Retry policy', slug: 'features/retry-policy' },
             { label: 'Structured logging', slug: 'features/logging' },
             { label: 'API mode', slug: 'features/api-mode' },

--- a/site/src/content/docs/features/lifecycle.mdx
+++ b/site/src/content/docs/features/lifecycle.mdx
@@ -1,0 +1,100 @@
+---
+title: Lifecycle events & suppression
+description: Delivery and bounce callbacks forwarded to your apps, and automatic suppression of dead addresses.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="note">Available from **v2.0**. Requires a [`[storage]` block](/features/storage/) — events are correlated against the submission log.</Aside>
+
+Without lifecycle events, delivery outcomes are invisible to your apps: Posthorn hands mail to your provider and the story ends. If a license email hard-bounces, the app that sent it never learns, and the next send to the same dead address dings your provider reputation again.
+
+The `[lifecycle]` block closes that loop for **Postmark**: Posthorn receives Postmark's webhooks, normalizes them, auto-suppresses dead addresses, and forwards events to the app that originated the mail.
+
+## Setup
+
+```toml
+[lifecycle]
+basic_auth_username = "postmark"
+basic_auth_password = "${env.POSTHORN_EVENTS_PASSWORD}"
+
+[[endpoints]]
+path = "/license-delivery"
+auth = "api-key"
+# ... endpoint config ...
+webhook_url    = "https://api.your-app.example/email-events"
+webhook_secret = "${env.YOUR_APP_WEBHOOK_SECRET}"   # 16+ bytes
+```
+
+Then point Postmark at Posthorn: in your Postmark server's settings, add a webhook to `https://your-posthorn.example/events/postmark` with the basic-auth credentials, and enable the event types you care about (Delivery, Bounce, Spam Complaint).
+
+<Aside type="caution">
+This is Posthorn's first endpoint a third party POSTs to, so it requires your Posthorn instance to be **reachable by Postmark's webhook senders**. Deliberately-internal deployments (homelab behind Tailscale, no inbound exposure) keep everything else in v2.0 — the retry queue, the suppression list via CLI — but can't receive events. Basic auth is mandatory and fail-closed: there is no way to run the endpoint open.
+</Aside>
+
+## The normalized event
+
+Your app receives one JSON shape regardless of provider dialect:
+
+```json
+{
+  "event": "hard_bounce",
+  "submission_id": "0d5aa9c8-...",
+  "endpoint": "/license-delivery",
+  "recipient": "customer@example.com",
+  "timestamp": "2026-08-02T10:00:00Z",
+  "provider": "postmark",
+  "provider_data": { "...": "raw Postmark payload" }
+}
+```
+
+`event` is one of `delivered`, `hard_bounce`, `soft_bounce`, `spam_complaint`, `opened`, `clicked`, `other`. `submission_id` matches the ID Posthorn returned when your app sent the mail — that's your join key.
+
+The normalized fields are the contract. `provider_data` carries the raw provider payload as a convenience; it changes when providers change, so don't build on it.
+
+## Verifying the signature
+
+Every forwarded event is signed. The `X-Posthorn-Signature` header carries `sha256=<hex>` — the HMAC-SHA256 of the exact request body under your `webhook_secret`:
+
+```go
+mac := hmac.New(sha256.New, []byte(secret))
+mac.Write(body)
+want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+ok := hmac.Equal([]byte(r.Header.Get("X-Posthorn-Signature")), []byte(want))
+```
+
+Respond `2xx` to acknowledge. On `5xx` or timeout, Posthorn retries with backoff (1m, 4m, 16m, ~1h, ~4h) and gives up after five attempts; on other `4xx` it drops the event immediately.
+
+## Automatic suppression
+
+Hard bounces and spam complaints add the address to a global suppression list automatically. Future sends to a suppressed address — through **any** endpoint or the SMTP listener — skip that recipient:
+
+- If every recipient is suppressed, HTTP callers get `200 {"status": "suppressed", "suppressed": {"addr": "reason"}}` — a 2xx because the request is terminally handled; retrying will never send it. SMTP clients get `250`.
+- Mixed recipient lists send to the clean addresses; the response's `suppressed` map names what was skipped.
+
+This protects your provider account: providers deactivate senders that keep mailing known-dead addresses. Soft bounces (full mailbox, greylisting) never suppress.
+
+## Managing the list
+
+Suppressions are managed from the CLI, not an HTTP API:
+
+```bash
+posthorn suppressions list --config ./posthorn.toml
+posthorn suppressions add spam-trap@example.com --config ./posthorn.toml
+posthorn suppressions remove recovered@example.com --config ./posthorn.toml
+```
+
+`remove` clears every entry for the address — also your GDPR-erasure path, since suppression rows are deliberately exempt from [retention pruning](/features/storage/) (forgetting a bounce would defeat the feature). The storage file is standard SQLite, so `sqlite3 posthorn.db 'SELECT * FROM suppressions'` works too.
+
+## Provider support
+
+v2.0 ingests **Postmark** events only. The normalized shape is provider-agnostic by design; other providers (Resend, Mailgun, SES-via-SNS) slot in behind it when demand shows up — [open an issue](https://github.com/craigmccaskill/posthorn/issues) with your provider and use case. Mail *sending* is unaffected: all five transports work with or without lifecycle.
+
+## Metrics
+
+| Metric | Meaning |
+|---|---|
+| `posthorn_lifecycle_events_total{event}` | Accepted, normalized events |
+| `posthorn_lifecycle_dropped_total{reason}` | Posts dropped (`unmatched` / `malformed`) |
+| `posthorn_lifecycle_forwards_total{endpoint,outcome}` | Callback deliveries (`sent` / `queued` / `dropped`) |
+| `posthorn_suppressed_recipients_total{endpoint}` | Recipients skipped by the suppression list |

--- a/site/src/content/docs/features/storage.mdx
+++ b/site/src/content/docs/features/storage.mdx
@@ -1,0 +1,76 @@
+---
+title: Storage & reliability
+description: The optional SQLite layer — submission log, retry queue across restarts, durable idempotency — and what living on disk means.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="note">Available from **v2.0**. Entirely optional: without a `[storage]` block, Posthorn behaves exactly like v1.x — nothing touches disk.</Aside>
+
+```toml
+[storage]
+path      = "/var/lib/posthorn/posthorn.db"
+retention = "30d"     # default; how long completed submissions stay queryable
+max_size  = "1GB"     # default; hard cap on the database file
+```
+
+One SQLite file, one Posthorn instance. The file must not be shared between concurrent instances.
+
+## What you get
+
+**A submission log.** Every submission persists: envelope, rendered bodies, raw form fields, status (`sent`, `queued`, `failed`, `suppressed`), the provider's message ID, timestamps. Query it with the stock tooling:
+
+```bash
+sqlite3 /var/lib/posthorn/posthorn.db \
+  "SELECT id, endpoint, status, created_at FROM submissions ORDER BY created_at DESC LIMIT 20"
+```
+
+**A retry queue that survives restarts.** In v1.x, a send that failed transiently (provider 5xx, network blip) after its inline retries was dropped — recoverable only from logs. With storage, that send enters a background queue and retries with backoff (1m, 4m, 16m, ~1h, ~4h) before being marked `failed`.
+
+**Durable idempotency.** API-mode `Idempotency-Key` responses survive restarts: a client retrying across a Posthorn redeploy gets the byte-identical cached response instead of a double-send.
+
+**The [suppression list](/features/lifecycle/#automatic-suppression).**
+
+## What 200 still means
+
+The response contract does not soften: **200 means sent**, and a 502 means terminally failed. The new state is additive — when inline retries exhaust on a *transient* failure (where v1.x dropped the mail), API-mode callers now receive:
+
+```json
+HTTP 202
+{"status": "queued", "submission_id": "0d5aa9c8-..."}
+```
+
+Any 2xx means *terminally handled — do not retry*. Form-mode submitters see the normal success response, and the SMTP listener answers `250` (the relay owns the retry). Track the eventual outcome by `submission_id` in the log, or via [lifecycle events](/features/lifecycle/).
+
+One honest caveat: queued delivery is **at-least-once**. If Posthorn crashes in the window between the provider accepting a send and Posthorn recording that fact, recovery re-sends. Duplicates are rare and bounded to crashes, but receivers that must deduplicate can key on the message content or your own idempotency scheme.
+
+## Failure posture: mail first
+
+Storage failure never blocks mail. A canary write probes the full disk path every 15 seconds; if it fails, Posthorn degrades to v1.x synchronous behavior — mail keeps flowing, nothing persists, no 202s are offered — and tells you loudly:
+
+- `/healthz` reports `{"status":"ok","storage":"degraded"}` (still HTTP 200 — a degraded disk is not a liveness failure and a restart wouldn't help)
+- `posthorn_storage_healthy` drops to 0
+- a `storage_degraded` log event fires on the transition, `storage_recovered` when the probe passes again
+
+Posthorn also cannot fill your disk: `max_size` is enforced inside SQLite (`max_page_count`), so the file stops growing at the cap while retention pruning keeps working. If some *other* process fills the volume to 100%, mail still flows in degraded mode until space is freed.
+
+## Data at rest — read this before enabling
+
+The storage file changes Posthorn's privacy posture, deliberately and visibly:
+
+**What's in the file.** Submitter PII: names, email addresses, message bodies (text and HTML), raw form fields, and client IPs — for up to `retention` (30 days by default). Suppression rows hold email addresses **indefinitely** by design: they're consent/deliverability memory, and forgetting a bounce defeats the feature.
+
+**What respects your existing flags.** `strip_client_ip = true` keeps IPs out of storage rows just as it keeps them out of logs. `log_failed_submissions = false` endpoints store metadata only (no bodies, no fields) — and consequently can't use the retry queue, since queueing *is* persisting submitter content.
+
+**The file is a theft target.** Treat it like a database, because it is one:
+
+- Own it with the Posthorn user, mode `0600`; same for the `-wal`/`-shm` siblings and the containing directory
+- Put it on an encrypted volume if the host is shared or physical access is a concern
+- Back it up like data, restore-test it, and remember backups extend the retention window in practice
+- Never expose the path via a web root or a container volume mounted elsewhere
+
+**Erasure.** Retention pruning handles submissions automatically. For a specific person: `posthorn suppressions remove <email>` clears suppression rows, and `sqlite3` deletes submission rows directly — `DELETE FROM submissions WHERE to_addrs LIKE '%person@example.com%';`
+
+## Sizing
+
+Text-only submissions are ~1-4KB each; HTML bodies grow with your templates; attachments (v2.0) persist as blobs while queued. The 1GB default holds months of typical contact-form traffic. Watch `posthorn_retry_queue_depth` — a rising queue with a full disk cap is the one state where mail can be accepted-then-dead-lettered for space.


### PR DESCRIPTION
Implements #8 and the minimal defensive slice of #4 (ADR-22/23). **Stacked on the #21-spine PR.**

**What's in:**
- `[lifecycle]` + `/events/postmark` (FR82): mandatory fail-closed basic auth (constant-time), per-IP rate limit, 256KB cap; authenticated posts always answer 200 (unmatched/malformed log + count instead of feeding provider retry storms)
- Normalization (FR83): fixed event enum behind a provider-agnostic shape; raw payload as best-effort `provider_data`; correlation via the submission log's message ID
- Signed forwarding (FR84): per-endpoint `webhook_url` + `webhook_secret` (≥16 bytes; requires `[lifecycle]` at parse time — ADR-10 tradition), HMAC `X-Posthorn-Signature`, inline attempt then queue ladder, byte-identical replays
- Auto-suppression (FR85): hard bounce + spam complaint → global rows; soft bounces never suppress
- Send-time suppression in both ingresses (FR86): "2xx = terminally handled" contract — HTTP `200 {"status":"suppressed"}` with per-recipient reasons / SMTP 250; mixed lists send the remainder; storage-less responses byte-identical to v1.x
- `posthorn suppressions list|add|remove` CLI (FR87) — no HTTP admin API; remove is the GDPR-erasure path
- Docs: lifecycle + storage/data-at-rest pages (NFR31 release blocker cleared)

**Testing:** normalization table, auth/rate/size gates, signature verification round-trip, suppression semantics on both ingresses, 5xx queue-and-replay vs 4xx drop, NFR29 sentinel secrets never logged, CLI round-trip on a real file. Full race suite green.

**Live validation deliberately not in this PR:** Postmark end-to-end needs a reachable deployment (Epic 18 / release checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013idJN57gmLPmHA79JnqeYE