### PR TITLE
fix(build): pin builder to Go 1.26.5 (CVE-2026-39822)

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -11,7 +11,7 @@
 # upstream can't silently change what we build from. Dependabot keeps
 # the digests fresh (.github/dependabot.yml); the tag comment is for
 # humans.
-FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 ARG VERSION=dev
 ARG TARGETOS=linux


### PR DESCRIPTION
The v2.0.0-rc.1 release build failed its Trivy scan gate: the `golang:1.26-alpine` digest pinned in the Dockerfile resolves to Go 1.26.4, whose stdlib carries CVE-2026-39822 (HIGH, `os.Root` symlink following — fixed in 1.26.5). Trivy flags the stdlib compiled into the shipped binary.

One-line fix: pin the builder to the `1.26.5-alpine` digest. `v2.0.0-rc.2` gets tagged from main once this merges (rc.1's tag stays pointing at its failed build; tags don't move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013idJN57gmLPmHA79JnqeYE