### PR TITLE
test: scripted live lifecycle validation + rc-tag CI gate (Story 18.3)

### DIFF
--- a/.github/workflows/lifecycle-live.yml
+++ b/.github/workflows/lifecycle-live.yml
@@ -1,0 +1,74 @@
+name: Lifecycle (live)
+
+# Story 18.3: the live lifecycle validation — real Postmark webhook
+# senders POSTing into a really-running posthorn binary, reachable via an
+# anonymous cloudflared quick tunnel (no Cloudflare account; the tunnel
+# URL is single-run ephemera). See docs/manual-test.md §"v2.0 lifecycle
+# live validation" for the full procedure and the local-run equivalent
+# (`make validate-lifecycle`).
+#
+# Same trust fencing as integration-live.yml — this touches a real
+# provider credential, so it never runs on pull_request and sits behind
+# the protected `live-providers` Environment:
+#   - POSTMARK_SERVER_TOKEN (environment secret): a real server token,
+#     ideally for a dedicated `posthorn-validation` Postmark server so
+#     validation traffic and its deliberate blackhole bounces stay out of
+#     production activity. Absent → the test SKIPS and the job goes green
+#     without validating anything; check the log, not just the badge.
+#   - POSTHORN_TEST_FROM / POSTHORN_TEST_TO (repo variables, shared with
+#     integration-live.yml): a verified sender signature and a real
+#     receiving mailbox.
+#
+# Triggers: manual dispatch, and rc tags — cutting a release candidate
+# runs the release-gate validation for it automatically.
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ['v*-rc*']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lifecycle-live
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    # Never run on forks — they have neither the secrets nor the trust.
+    if: github.repository == 'craigmccaskill/posthorn'
+    runs-on: ubuntu-latest
+    environment: live-providers
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: core/go.mod
+
+      # Pinned by version AND sha256, matching the repo's digest-pinning
+      # discipline (#39/#56). Update both together; the digest is listed
+      # on the cloudflared release page.
+      - name: Install cloudflared (pinned)
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -fsSL -o cloudflared \
+            https://github.com/cloudflare/cloudflared/releases/download/2026.9.0/cloudflared-linux-amd64
+          echo "53b7a7a5420d188758d24341294acb0d1bca54296548ac05e38811a694ac6134  cloudflared" | sha256sum -c -
+          chmod +x cloudflared
+          echo "${{ runner.temp }}" >> "$GITHUB_PATH"
+
+      - name: Live lifecycle validation
+        env:
+          POSTMARK_SERVER_TOKEN: ${{ secrets.POSTMARK_SERVER_TOKEN }}
+          POSTHORN_TEST_FROM: ${{ vars.POSTHORN_TEST_FROM }}
+          POSTHORN_TEST_TO: ${{ vars.POSTHORN_TEST_TO }}
+        run: go test -tags lifecyclelive -count=1 -v -timeout=15m -run TestLifecycleLive ./providertest/

--- a/.github/workflows/lifecycle-live.yml
+++ b/.github/workflows/lifecycle-live.yml
@@ -13,8 +13,10 @@ name: Lifecycle (live)
 #   - POSTMARK_SERVER_TOKEN (environment secret): a real server token,
 #     ideally for a dedicated `posthorn-validation` Postmark server so
 #     validation traffic and its deliberate blackhole bounces stay out of
-#     production activity. Absent → the test SKIPS and the job goes green
-#     without validating anything; check the log, not just the badge.
+#     production activity. Absent on MANUAL DISPATCH → the test skips
+#     (the workflow can be exercised before secrets exist). Absent on an
+#     RC TAG → the job FAILS: a tag's validation run is release
+#     evidence, and a skipped gate must never read as a green one.
 #   - POSTHORN_TEST_FROM / POSTHORN_TEST_TO (repo variables, shared with
 #     integration-live.yml): a verified sender signature and a real
 #     receiving mailbox.
@@ -65,6 +67,18 @@ jobs:
           echo "53b7a7a5420d188758d24341294acb0d1bca54296548ac05e38811a694ac6134  cloudflared" | sha256sum -c -
           chmod +x cloudflared
           echo "${{ runner.temp }}" >> "$GITHUB_PATH"
+
+      # Rc tags are the release gate; without the secret the test would
+      # skip and the badge would still show green. Refuse instead.
+      - name: Refuse to skip the release gate (rc tags only)
+        if: github.ref_type == 'tag'
+        env:
+          POSTMARK_SERVER_TOKEN: ${{ secrets.POSTMARK_SERVER_TOKEN }}
+        run: |
+          if [ -z "$POSTMARK_SERVER_TOKEN" ]; then
+            echo "::error::POSTMARK_SERVER_TOKEN is not set in the live-providers environment. An rc tag's validation run is release evidence; refusing to pass on a skip."
+            exit 1
+          fi
 
       - name: Live lifecycle validation
         env:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #
 # No third-party key is ever required to run `make test`.
 
-.PHONY: test test-live lint fmt vet cover build site help
+.PHONY: test test-live validate-lifecycle lint fmt vet cover build site help
 .DEFAULT_GOAL := help
 
 test: ## Hermetic test suite with the race detector (default PR gate)
@@ -21,6 +21,9 @@ test: ## Hermetic test suite with the race detector (default PR gate)
 
 test-live: ## Live tier (-tags integration): real APIs, non-delivering targets
 	cd core && go test -tags integration -race -count=1 -timeout=5m ./providertest/...
+
+validate-lifecycle: ## Story 18.3: live lifecycle validation (real Postmark + quick tunnel; needs POSTMARK_SERVER_TOKEN, POSTHORN_TEST_FROM/TO, cloudflared)
+	cd core && go test -tags lifecyclelive -count=1 -v -timeout=15m -run TestLifecycleLive ./providertest/
 
 lint: ## golangci-lint
 	cd core && golangci-lint run

--- a/core/providertest/lifecyclelive_test.go
+++ b/core/providertest/lifecyclelive_test.go
@@ -1,0 +1,421 @@
+//go:build lifecyclelive
+
+// Story 18.3: the live lifecycle validation. This is the release-gate
+// check that the v2.0 lifecycle loop works against the real world — real
+// Postmark webhook senders POSTing into a really-running posthorn binary
+// — which the hermetic suite cannot prove (it fakes Postmark's side).
+//
+// It is deliberately runnable by anyone, anywhere, with no standing
+// infrastructure: the posthorn under test runs locally from a generated
+// config, and reachability for Postmark's webhooks comes from an
+// anonymous cloudflared "quick tunnel" (no Cloudflare account, no
+// credentials, ephemeral URL). The only secret is POSTMARK_SERVER_TOKEN.
+// Absent → the test SKIPS, same convention as the -tags integration
+// live tier.
+//
+// What one run proves, in order:
+//  1. A real send through the built binary reaches Postmark (delivery leg).
+//  2. Postmark's Delivery webhook lands on /events/postmark through the
+//     tunnel, authenticates (FR82), correlates (FR83), and is forwarded
+//     to the endpoint's webhook_url with a valid HMAC (FR84).
+//  3. A send to Postmark's blackhole bounce address produces a real
+//     hard-bounce event end-to-end the same way.
+//  4. The hard bounce auto-inserts a suppression row (FR85) and a
+//     follow-up send answers 200 {"status":"suppressed"} (FR86).
+//  5. `posthorn suppressions list` shows the row (FR87).
+//
+// Run via `make validate-lifecycle`. Requires `cloudflared` on PATH.
+package providertest
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	// posthornStartTimeout bounds waiting for /healthz on the local binary.
+	posthornStartTimeout = 30 * time.Second
+	// tunnelStartTimeout bounds cloudflared printing its quick-tunnel URL.
+	tunnelStartTimeout = 90 * time.Second
+	// tunnelReachableTimeout bounds the tunnel actually routing traffic —
+	// cloudflared warns the URL "may take some time to be reachable".
+	tunnelReachableTimeout = 2 * time.Minute
+	// eventTimeout bounds each leg's wait for Postmark to deliver the
+	// webhook. Delivery to a real mailbox plus webhook dispatch is
+	// usually well under a minute; the ceiling absorbs provider lag.
+	eventTimeout = 5 * time.Minute
+	// suppressionTimeout bounds the follow-up-send-is-suppressed check.
+	suppressionTimeout = 60 * time.Second
+)
+
+func TestLifecycleLive_PostmarkEndToEnd(t *testing.T) {
+	token := os.Getenv("POSTMARK_SERVER_TOKEN")
+	if token == "" {
+		t.Skip("POSTMARK_SERVER_TOKEN not set — skipping live lifecycle validation")
+	}
+	from := os.Getenv("POSTHORN_TEST_FROM")
+	deliveryTo := os.Getenv("POSTHORN_TEST_TO")
+	if from == "" || deliveryTo == "" {
+		t.Fatal("POSTHORN_TEST_FROM and POSTHORN_TEST_TO must be set: FROM must be a verified sender signature on the Postmark server, TO a real mailbox that accepts mail")
+	}
+	cloudflared, err := exec.LookPath("cloudflared")
+	if err != nil {
+		t.Fatal("cloudflared not found on PATH — install it (https://github.com/cloudflare/cloudflared/releases); the quick tunnel needs no account or credentials")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dir := t.TempDir()
+
+	// --- Build the binary under test.
+	bin := filepath.Join(dir, "posthorn")
+	build := exec.CommandContext(ctx, "go", "build", "-o", bin, "github.com/craigmccaskill/posthorn/cmd/posthorn")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+
+	// --- Receiver: the stand-in operator app the events must reach.
+	webhookSecret := randomToken(t)
+	rec := newEventReceiver(webhookSecret)
+	recSrv := httptest.NewServer(rec)
+	defer recSrv.Close()
+
+	// --- Config + posthorn under test.
+	basicUser, basicPass := "lifecycle-validate", randomToken(t)
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := lifecycleValidationConfig(lifecycleValidationOpts{
+		DBPath:        filepath.Join(dir, "validate.db"),
+		BasicAuthUser: basicUser,
+		BasicAuthPass: basicPass,
+		From:          from,
+		DeliveryTo:    deliveryTo,
+		WebhookURL:    recSrv.URL + "/events",
+		WebhookSecret: webhookSecret,
+	})
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	listen := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+	posthornLog := startProcess(t, ctx, bin, "serve", "--config", cfgPath, "--listen", listen)
+	waitHTTP(t, "http://"+listen+"/healthz", posthornStartTimeout, "posthorn /healthz")
+	t.Logf("posthorn under test listening on %s", listen)
+
+	// --- Quick tunnel: the ephemeral public URL Postmark will POST to.
+	tunnelURL := startQuickTunnel(t, ctx, cloudflared, "http://"+listen)
+	t.Logf("quick tunnel: %s", tunnelURL)
+	waitHTTP(t, tunnelURL+"/healthz", tunnelReachableTimeout, "tunnel routing")
+
+	// --- Postmark server hygiene + webhook registration.
+	pm := &postmarkServerAPI{Token: token}
+	cleanupStaleWebhooks(t, pm)
+	// Postmark suppresses the blackhole address on its own list after
+	// each bounce; clear it so this run's bounce send actually goes out.
+	if err := pm.DeleteSuppressions(ctx, "outbound", []string{postmarkHardBounceAddress}); err != nil {
+		t.Fatalf("clearing provider-side suppression of the blackhole address: %v", err)
+	}
+	hookID, err := pm.CreateWebhook(ctx, postmarkWebhookRequest{
+		URL:           tunnelURL + "/events/postmark",
+		MessageStream: "outbound",
+		HTTPAuth:      postmarkWebhookAuth{Username: basicUser, Password: basicPass},
+		Triggers:      validationTriggers(),
+	})
+	if err != nil {
+		t.Fatalf("registering webhook on Postmark: %v", err)
+	}
+	t.Logf("registered Postmark webhook %d → %s/events/postmark", hookID, tunnelURL)
+	defer func() {
+		// Teardown uses a fresh context: the test context may be done.
+		dctx, dcancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer dcancel()
+		if err := pm.DeleteWebhook(dctx, hookID); err != nil {
+			t.Errorf("teardown: deleting webhook %d failed (next run's stale-webhook sweep will catch it): %v", hookID, err)
+		}
+	}()
+
+	runID := randomToken(t)
+
+	// --- Leg 1: delivery.
+	subDelivery := submitForm(t, "http://"+listen+"/validate/delivery", runID)
+	t.Logf("delivery-leg submission %s accepted; waiting for the delivered event", subDelivery)
+	ev := waitForEvent(t, rec, "delivered", subDelivery)
+	assertEvent(t, ev, "/validate/delivery")
+
+	// --- Leg 2: hard bounce.
+	subBounce := submitForm(t, "http://"+listen+"/validate/bounce", runID)
+	t.Logf("bounce-leg submission %s accepted; waiting for the hard_bounce event", subBounce)
+	ev = waitForEvent(t, rec, "hard_bounce", subBounce)
+	assertEvent(t, ev, "/validate/bounce")
+
+	// --- Leg 3: the suppression the bounce must have created (FR85/86).
+	waitForSuppressedSend(t, "http://"+listen+"/validate/bounce", runID)
+
+	// --- Leg 4: the CLI management surface (FR87).
+	list := exec.CommandContext(ctx, bin, "suppressions", "list", "--config", cfgPath)
+	out, err := list.CombinedOutput()
+	if err != nil {
+		t.Fatalf("posthorn suppressions list: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), postmarkHardBounceAddress) {
+		t.Errorf("suppressions list does not show %s:\n%s", postmarkHardBounceAddress, out)
+	}
+
+	t.Logf("lifecycle validation passed: delivery + hard_bounce forwarded with valid signatures, suppression enforced, CLI lists the row")
+	_ = posthornLog // referenced so the capture lives for the whole run
+}
+
+// randomToken returns 24 hex chars from crypto/rand — used for the
+// basic-auth password, webhook secret (>=16 bytes per config
+// validation), and run ID.
+func randomToken(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// startProcess launches a subprocess wired into the test lifecycle: its
+// combined output is captured (and dumped on failure), and it is killed
+// via t.Cleanup. Returns the output buffer.
+func startProcess(t *testing.T, ctx context.Context, name string, args ...string) *lockedBuffer {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, name, args...)
+	buf := &lockedBuffer{}
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if t.Failed() {
+			t.Logf("--- output of %s ---\n%s", filepath.Base(name), buf.String())
+		}
+	})
+	return buf
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// startQuickTunnel runs `cloudflared tunnel --url <target>` and returns
+// the ephemeral trycloudflare.com URL it prints. The process dies with
+// the test via t.Cleanup.
+func startQuickTunnel(t *testing.T, ctx context.Context, cloudflared, target string) string {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, cloudflared, "tunnel", "--url", target)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting cloudflared: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	urlCh := make(chan string, 1)
+	scan := func(r io.Reader) {
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			if u, ok := parseQuickTunnelURL(sc.Text()); ok {
+				select {
+				case urlCh <- u:
+				default:
+				}
+			}
+		}
+	}
+	go scan(stdout)
+	go scan(stderr)
+
+	select {
+	case u := <-urlCh:
+		return u
+	case <-time.After(tunnelStartTimeout):
+		t.Fatal("cloudflared did not print a quick-tunnel URL in time — check outbound connectivity (QUIC 7844 or HTTPS 443)")
+		return ""
+	}
+}
+
+// waitHTTP polls a URL until it answers 200.
+func waitHTTP(t *testing.T, url string, timeout time.Duration, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: 10 * time.Second}
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("%s not ready after %s: %v", what, timeout, lastErr)
+}
+
+// submitForm POSTs the validation form and returns the submission_id
+// from the Success envelope.
+func submitForm(t *testing.T, endpoint, runID string) string {
+	t.Helper()
+	resp, err := http.PostForm(endpoint, url.Values{"run_id": {runID}})
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s: HTTP %d: %s", endpoint, resp.StatusCode, body)
+	}
+	var success struct {
+		Status       string `json:"status"`
+		SubmissionID string `json:"submission_id"`
+	}
+	if err := json.Unmarshal(body, &success); err != nil {
+		t.Fatalf("POST %s: response not JSON: %v: %s", endpoint, err, body)
+	}
+	if success.SubmissionID == "" {
+		t.Fatalf("POST %s: no submission_id in response: %s", endpoint, body)
+	}
+	return success.SubmissionID
+}
+
+// waitForEvent drains the receiver until an event with the wanted type
+// and submission ID arrives. Unrelated events (a late event from a prior
+// leg, Postmark noise) are logged and skipped, not failed on.
+func waitForEvent(t *testing.T, rec *eventReceiver, wantEvent, wantSubmission string) receivedEvent {
+	t.Helper()
+	deadline := time.After(eventTimeout)
+	for {
+		select {
+		case ev := <-rec.Events:
+			if ev.Event == wantEvent && ev.SubmissionID == wantSubmission {
+				return ev
+			}
+			t.Logf("ignoring event %q for submission %q (waiting for %q/%q)", ev.Event, ev.SubmissionID, wantEvent, wantSubmission)
+		case <-deadline:
+			t.Fatalf("no %q event for submission %s within %s — check the Postmark server's webhook activity for delivery errors", wantEvent, wantSubmission, eventTimeout)
+		}
+	}
+}
+
+func assertEvent(t *testing.T, ev receivedEvent, wantEndpoint string) {
+	t.Helper()
+	if !ev.SignatureOK {
+		t.Errorf("event %q: X-Posthorn-Signature did not verify against the shared secret", ev.Event)
+	}
+	if ev.Endpoint != wantEndpoint {
+		t.Errorf("event %q: endpoint = %q, want %q", ev.Event, ev.Endpoint, wantEndpoint)
+	}
+}
+
+// waitForSuppressedSend re-submits until the response is the FR86
+// suppressed contract. The suppression row is written during event
+// ingestion, which completed before the forwarded event was observed,
+// so this normally succeeds on the first try; the retry loop absorbs
+// any write-visibility lag.
+func waitForSuppressedSend(t *testing.T, endpoint, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(suppressionTimeout)
+	var last string
+	for time.Now().Before(deadline) {
+		resp, err := http.PostForm(endpoint, url.Values{"run_id": {runID}})
+		if err != nil {
+			t.Fatalf("POST %s: %v", endpoint, err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		_ = resp.Body.Close()
+		var success struct {
+			Status     string            `json:"status"`
+			Suppressed map[string]string `json:"suppressed"`
+		}
+		_ = json.Unmarshal(body, &success)
+		if resp.StatusCode == http.StatusOK && success.Status == "suppressed" {
+			if reason := success.Suppressed[postmarkHardBounceAddress]; reason != "hard_bounce" {
+				t.Errorf("suppressed reason for %s = %q, want %q (body: %s)", postmarkHardBounceAddress, reason, "hard_bounce", body)
+			}
+			return
+		}
+		last = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, body)
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("send to the bounced address was never suppressed within %s; last response: %s", suppressionTimeout, last)
+}
+
+// cleanupStaleWebhooks removes leftover trycloudflare registrations from
+// crashed or cancelled runs. Quick-tunnel URLs are single-run ephemera:
+// any registration pointing at one is dead by definition.
+func cleanupStaleWebhooks(t *testing.T, pm *postmarkServerAPI) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	hooks, err := pm.ListWebhooks(ctx)
+	if err != nil {
+		t.Fatalf("listing existing Postmark webhooks: %v", err)
+	}
+	for _, h := range hooks {
+		if strings.Contains(h.URL, ".trycloudflare.com") {
+			if err := pm.DeleteWebhook(ctx, h.ID); err != nil {
+				t.Fatalf("deleting stale webhook %d (%s): %v", h.ID, h.URL, err)
+			}
+			t.Logf("deleted stale webhook %d → %s", h.ID, h.URL)
+		}
+	}
+}

--- a/core/providertest/lifecycleval.go
+++ b/core/providertest/lifecycleval.go
@@ -1,0 +1,323 @@
+// Lifecycle live-validation support (Story 18.3). These helpers back the
+// `-tags lifecyclelive` orchestration in lifecyclelive_test.go: a minimal
+// Postmark server-API client (webhook registration + suppression
+// hygiene), the cloudflared quick-tunnel URL parser, the forwarded-event
+// receiver with independent HMAC verification, and the generated
+// validation config. They carry no build tag so the hermetic suite
+// (`make test`) exercises them on every PR; only the orchestration that
+// touches the real Postmark API and a real tunnel is tagged.
+//
+// The receiver recomputes the X-Posthorn-Signature HMAC itself rather
+// than importing core/lifecycle's signer: the point of the validation is
+// that an INDEPENDENT consumer, holding only the shared secret and the
+// documented contract, can verify what Posthorn forwards.
+package providertest
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sync"
+	"time"
+)
+
+// postmarkHardBounceAddress is Postmark's documented blackhole address:
+// sending to it generates a real hard-bounce event (and webhook) without
+// affecting sender reputation or bounce limits. Postmark also adds it to
+// the server's own suppression list after each bounce, so runs must
+// clear it first via DeleteSuppressions — otherwise the next run's send
+// is suppressed provider-side and no bounce event ever fires.
+// https://postmarkapp.com/support/article/1239-how-to-test-bounces
+const postmarkHardBounceAddress = "hardbounce@bounce-testing.postmarkapp.com"
+
+// postmarkAPIBase is the production Postmark server-API endpoint.
+// Injectable on postmarkServerAPI for hermetic tests.
+const postmarkAPIBase = "https://api.postmarkapp.com"
+
+// postmarkServerAPI is a minimal client for the two server-API surfaces
+// the validation needs: webhook CRUD and suppression deletion. Bespoke
+// per ADR-1; the whole thing is well under the ~200-line bar.
+type postmarkServerAPI struct {
+	Token   string // X-Postmark-Server-Token; never logged (NFR3 discipline)
+	BaseURL string // defaults to postmarkAPIBase when empty
+	Client  *http.Client
+}
+
+func (p *postmarkServerAPI) base() string {
+	if p.BaseURL != "" {
+		return p.BaseURL
+	}
+	return postmarkAPIBase
+}
+
+func (p *postmarkServerAPI) client() *http.Client {
+	if p.Client != nil {
+		return p.Client
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func (p *postmarkServerAPI) do(ctx context.Context, method, path string, body any, out any) error {
+	var rd io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("postmark api: marshal %s %s: %w", method, path, err)
+		}
+		rd = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, p.base()+path, rd)
+	if err != nil {
+		return fmt.Errorf("postmark api: build %s %s: %w", method, path, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-Postmark-Server-Token", p.Token)
+	resp, err := p.client().Do(req)
+	if err != nil {
+		return fmt.Errorf("postmark api: %s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("postmark api: %s %s: HTTP %d: %s", method, path, resp.StatusCode, respBody)
+	}
+	if out != nil {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("postmark api: decode %s %s: %w", method, path, err)
+		}
+	}
+	return nil
+}
+
+// postmarkWebhook is the subset of the webhook resource the validation
+// reads back: enough to identify and delete stale registrations.
+type postmarkWebhook struct {
+	ID  int64  `json:"ID"`
+	URL string `json:"Url"`
+}
+
+// postmarkWebhookRequest is the creation payload. HttpAuth carries the
+// generated basic-auth pair Posthorn's /events/postmark requires (FR82);
+// Postmark supports it natively, per the LifecycleConfig doc comment.
+type postmarkWebhookRequest struct {
+	URL           string                  `json:"Url"`
+	MessageStream string                  `json:"MessageStream"`
+	HTTPAuth      postmarkWebhookAuth     `json:"HttpAuth"`
+	Triggers      postmarkWebhookTriggers `json:"Triggers"`
+}
+
+type postmarkWebhookAuth struct {
+	Username string `json:"Username"`
+	Password string `json:"Password"`
+}
+
+type postmarkWebhookTriggers struct {
+	Delivery      postmarkTrigger `json:"Delivery"`
+	Bounce        postmarkTrigger `json:"Bounce"`
+	SpamComplaint postmarkTrigger `json:"SpamComplaint"`
+}
+
+type postmarkTrigger struct {
+	Enabled        bool `json:"Enabled"`
+	IncludeContent bool `json:"IncludeContent,omitempty"`
+}
+
+// validationTriggers enables exactly the event classes Posthorn ingests
+// in v2.0's minimal slice: Delivery (the happy path), Bounce (the
+// suppression trigger), SpamComplaint (the other suppression trigger).
+func validationTriggers() postmarkWebhookTriggers {
+	return postmarkWebhookTriggers{
+		Delivery:      postmarkTrigger{Enabled: true},
+		Bounce:        postmarkTrigger{Enabled: true},
+		SpamComplaint: postmarkTrigger{Enabled: true},
+	}
+}
+
+// ListWebhooks returns the server's registered webhooks (outbound stream).
+func (p *postmarkServerAPI) ListWebhooks(ctx context.Context) ([]postmarkWebhook, error) {
+	var out struct {
+		Webhooks []postmarkWebhook `json:"Webhooks"`
+	}
+	if err := p.do(ctx, http.MethodGet, "/webhooks?MessageStream=outbound", nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Webhooks, nil
+}
+
+// CreateWebhook registers a webhook and returns its ID for teardown.
+func (p *postmarkServerAPI) CreateWebhook(ctx context.Context, req postmarkWebhookRequest) (int64, error) {
+	var out struct {
+		ID int64 `json:"ID"`
+	}
+	if err := p.do(ctx, http.MethodPost, "/webhooks", req, &out); err != nil {
+		return 0, err
+	}
+	return out.ID, nil
+}
+
+// DeleteWebhook removes a webhook registration by ID.
+func (p *postmarkServerAPI) DeleteWebhook(ctx context.Context, id int64) error {
+	return p.do(ctx, http.MethodDelete, fmt.Sprintf("/webhooks/%d", id), nil, nil)
+}
+
+// DeleteSuppressions removes addresses from the stream's provider-side
+// suppression list. Postmark caps requests at 50 addresses; the
+// validation only ever sends one (the blackhole address), so no batching.
+func (p *postmarkServerAPI) DeleteSuppressions(ctx context.Context, stream string, emails []string) error {
+	type entry struct {
+		EmailAddress string `json:"EmailAddress"`
+	}
+	body := struct {
+		Suppressions []entry `json:"Suppressions"`
+	}{}
+	for _, e := range emails {
+		body.Suppressions = append(body.Suppressions, entry{EmailAddress: e})
+	}
+	return p.do(ctx, http.MethodPost, "/message-streams/"+stream+"/suppressions/delete", body, nil)
+}
+
+// quickTunnelURLPattern matches the ephemeral URL cloudflared prints when
+// establishing an anonymous quick tunnel (no account, no credentials).
+var quickTunnelURLPattern = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
+
+// parseQuickTunnelURL extracts the quick-tunnel URL from a line of
+// cloudflared output. cloudflared prints it inside a decorated banner on
+// stderr; scanning line-by-line with this is resilient to the framing.
+func parseQuickTunnelURL(line string) (string, bool) {
+	m := quickTunnelURLPattern.FindString(line)
+	return m, m != ""
+}
+
+// verifyEventSignature checks an X-Posthorn-Signature header value
+// ("sha256=<hex>", FR84) against the body using the shared secret,
+// recomputed independently of core/lifecycle.
+func verifyEventSignature(secret string, body []byte, header string) bool {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(want), []byte(header))
+}
+
+// receivedEvent is one forwarded lifecycle callback as seen by the
+// validation's receiver: the normalized fields the assertions need, the
+// raw body, and whether the HMAC verified.
+type receivedEvent struct {
+	Event        string `json:"event"`
+	SubmissionID string `json:"submission_id"`
+	Endpoint     string `json:"endpoint"`
+	Recipient    string `json:"recipient"`
+	SignatureOK  bool   `json:"-"`
+	Raw          []byte `json:"-"`
+}
+
+// eventReceiver is the stand-in for an operator's app: it accepts
+// Posthorn's forwarded lifecycle callbacks, verifies the signature, and
+// hands each event to the test over a channel. Always answers 200 so
+// Posthorn's forwarder never retries against it.
+type eventReceiver struct {
+	secret string
+	Events chan receivedEvent
+
+	mu  sync.Mutex
+	all []receivedEvent
+}
+
+func newEventReceiver(secret string) *eventReceiver {
+	return &eventReceiver{secret: secret, Events: make(chan receivedEvent, 64)}
+}
+
+func (r *eventReceiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(req.Body, 1<<20))
+	if err != nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	var ev receivedEvent
+	_ = json.Unmarshal(body, &ev)
+	ev.Raw = body
+	ev.SignatureOK = verifyEventSignature(r.secret, body, req.Header.Get("X-Posthorn-Signature"))
+	r.mu.Lock()
+	r.all = append(r.all, ev)
+	r.mu.Unlock()
+	select {
+	case r.Events <- ev:
+	default: // never block Posthorn's forwarder on a full channel
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// lifecycleValidationOpts parameterizes the generated validation config.
+type lifecycleValidationOpts struct {
+	DBPath        string // SQLite file inside the run's temp dir
+	BasicAuthUser string // generated per run
+	BasicAuthPass string // generated per run
+	From          string // verified Postmark sender signature
+	DeliveryTo    string // real mailbox that accepts mail (Delivery events only fire on acceptance)
+	WebhookURL    string // the local eventReceiver
+	WebhookSecret string // generated per run
+}
+
+// lifecycleValidationConfig renders the TOML config the validation runs
+// Posthorn under: storage + lifecycle enabled, one delivery-leg endpoint
+// and one bounce-leg endpoint (Postmark's blackhole address), both
+// forwarding events to the receiver. The Postmark token is referenced as
+// an ${env...} placeholder so it never touches disk (NFR3 discipline);
+// the posthorn process inherits it from the test environment.
+func lifecycleValidationConfig(o lifecycleValidationOpts) string {
+	return fmt.Sprintf(`# Generated by the Story 18.3 lifecycle validation run. Ephemeral.
+
+[storage]
+path = %q
+
+[lifecycle]
+basic_auth_username = %q
+basic_auth_password = %q
+
+[[endpoints]]
+path = "/validate/delivery"
+to = [%q]
+from = %q
+subject = "Posthorn lifecycle validation (delivery leg)"
+body = "Story 18.3 delivery-leg send. run_id: {{.run_id}}"
+required = ["run_id"]
+webhook_url = %q
+webhook_secret = %q
+
+[endpoints.transport]
+type = "postmark"
+
+[endpoints.transport.settings]
+api_key = "${env.POSTMARK_SERVER_TOKEN}"
+
+[[endpoints]]
+path = "/validate/bounce"
+to = [%q]
+from = %q
+subject = "Posthorn lifecycle validation (bounce leg)"
+body = "Story 18.3 bounce-leg send. run_id: {{.run_id}}"
+required = ["run_id"]
+webhook_url = %q
+webhook_secret = %q
+
+[endpoints.transport]
+type = "postmark"
+
+[endpoints.transport.settings]
+api_key = "${env.POSTMARK_SERVER_TOKEN}"
+`,
+		o.DBPath,
+		o.BasicAuthUser, o.BasicAuthPass,
+		o.DeliveryTo, o.From, o.WebhookURL, o.WebhookSecret,
+		postmarkHardBounceAddress, o.From, o.WebhookURL, o.WebhookSecret,
+	)
+}

--- a/core/providertest/lifecycleval_test.go
+++ b/core/providertest/lifecycleval_test.go
@@ -1,0 +1,326 @@
+// Hermetic tests for the lifecycle live-validation support code. These
+// run in the default suite on every PR: the Postmark API client is
+// exercised against a fake server, the generated config is loaded
+// through the real config.Load, and the receiver's independent HMAC
+// verification is checked against the documented FR84 contract. The
+// tagged orchestration in lifecyclelive_test.go is the only part that
+// needs a network.
+package providertest
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/craigmccaskill/posthorn/config"
+)
+
+func TestParseQuickTunnelURL(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+		ok   bool
+	}{
+		{
+			"banner_line",
+			"2026-09-09T10:00:00Z INF |  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |",
+			"", false,
+		},
+		{
+			"url_line",
+			"2026-09-09T10:00:00Z INF |  https://tame-poem-example-quick.trycloudflare.com                                         |",
+			"https://tame-poem-example-quick.trycloudflare.com", true,
+		},
+		{"bare_url", "https://a1-b2.trycloudflare.com", "https://a1-b2.trycloudflare.com", true},
+		{"unrelated_url", "connecting to https://api.trycloudflare.example.com", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseQuickTunnelURL(tt.line)
+			if ok != tt.ok || got != tt.want {
+				t.Errorf("parseQuickTunnelURL(%q) = (%q, %v), want (%q, %v)", tt.line, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestVerifyEventSignature(t *testing.T) {
+	secret := "validation-webhook-secret"
+	body := []byte(`{"event":"delivered","submission_id":"abc"}`)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	good := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	if !verifyEventSignature(secret, body, good) {
+		t.Error("valid signature rejected")
+	}
+	if verifyEventSignature(secret, body, "sha256=deadbeef") {
+		t.Error("wrong signature accepted")
+	}
+	if verifyEventSignature(secret, append(body, ' '), good) {
+		t.Error("tampered body accepted")
+	}
+	if verifyEventSignature("other-secret", body, good) {
+		t.Error("wrong secret accepted")
+	}
+	if verifyEventSignature(secret, body, "") {
+		t.Error("empty header accepted")
+	}
+}
+
+// fakePostmarkAPI records requests so the tests can assert the exact
+// wire shape the client produces.
+type fakePostmarkAPI struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+	respond  func(w http.ResponseWriter, r *http.Request)
+}
+
+type recordedRequest struct {
+	Method string
+	Path   string
+	Token  string
+	Body   []byte
+}
+
+func (f *fakePostmarkAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	f.mu.Lock()
+	f.requests = append(f.requests, recordedRequest{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Token:  r.Header.Get("X-Postmark-Server-Token"),
+		Body:   body,
+	})
+	f.mu.Unlock()
+	if f.respond != nil {
+		f.respond(w, r)
+		return
+	}
+	_, _ = w.Write([]byte(`{}`))
+}
+
+func (f *fakePostmarkAPI) last(t *testing.T) recordedRequest {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.requests) == 0 {
+		t.Fatal("no request reached the fake Postmark API")
+	}
+	return f.requests[len(f.requests)-1]
+}
+
+func TestPostmarkServerAPI_CreateWebhook(t *testing.T) {
+	fake := &fakePostmarkAPI{respond: func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ID": 4242}`))
+	}}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	api := &postmarkServerAPI{Token: "sentinel-server-token", BaseURL: srv.URL, Client: srv.Client()}
+	id, err := api.CreateWebhook(context.Background(), postmarkWebhookRequest{
+		URL:           "https://example.trycloudflare.com/events/postmark",
+		MessageStream: "outbound",
+		HTTPAuth:      postmarkWebhookAuth{Username: "u", Password: "p"},
+		Triggers:      validationTriggers(),
+	})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	if id != 4242 {
+		t.Errorf("ID = %d, want 4242", id)
+	}
+
+	req := fake.last(t)
+	if req.Method != http.MethodPost || req.Path != "/webhooks" {
+		t.Errorf("request = %s %s, want POST /webhooks", req.Method, req.Path)
+	}
+	if req.Token != "sentinel-server-token" {
+		t.Errorf("token header = %q", req.Token)
+	}
+	var sent map[string]json.RawMessage
+	if err := json.Unmarshal(req.Body, &sent); err != nil {
+		t.Fatalf("request body not JSON: %v", err)
+	}
+	for _, key := range []string{"Url", "MessageStream", "HttpAuth", "Triggers"} {
+		if _, ok := sent[key]; !ok {
+			t.Errorf("request body missing %q key: %s", key, req.Body)
+		}
+	}
+	if !bytes.Contains(req.Body, []byte(`"Delivery":{"Enabled":true}`)) {
+		t.Errorf("Delivery trigger not enabled in body: %s", req.Body)
+	}
+}
+
+func TestPostmarkServerAPI_ListAndDeleteWebhooks(t *testing.T) {
+	fake := &fakePostmarkAPI{respond: func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"Webhooks":[{"ID":1,"Url":"https://old.trycloudflare.com/events/postmark"},{"ID":2,"Url":"https://apps.example.com/hook"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	api := &postmarkServerAPI{Token: "t", BaseURL: srv.URL, Client: srv.Client()}
+	hooks, err := api.ListWebhooks(context.Background())
+	if err != nil {
+		t.Fatalf("ListWebhooks: %v", err)
+	}
+	if len(hooks) != 2 || hooks[0].ID != 1 || hooks[0].URL != "https://old.trycloudflare.com/events/postmark" {
+		t.Errorf("unexpected webhooks: %+v", hooks)
+	}
+
+	if err := api.DeleteWebhook(context.Background(), 1); err != nil {
+		t.Fatalf("DeleteWebhook: %v", err)
+	}
+	req := fake.last(t)
+	if req.Method != http.MethodDelete || req.Path != "/webhooks/1" {
+		t.Errorf("request = %s %s, want DELETE /webhooks/1", req.Method, req.Path)
+	}
+}
+
+func TestPostmarkServerAPI_DeleteSuppressions(t *testing.T) {
+	fake := &fakePostmarkAPI{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	api := &postmarkServerAPI{Token: "t", BaseURL: srv.URL, Client: srv.Client()}
+	if err := api.DeleteSuppressions(context.Background(), "outbound", []string{postmarkHardBounceAddress}); err != nil {
+		t.Fatalf("DeleteSuppressions: %v", err)
+	}
+	req := fake.last(t)
+	if req.Method != http.MethodPost || req.Path != "/message-streams/outbound/suppressions/delete" {
+		t.Errorf("request = %s %s, want POST /message-streams/outbound/suppressions/delete", req.Method, req.Path)
+	}
+	want := `{"Suppressions":[{"EmailAddress":"` + postmarkHardBounceAddress + `"}]}`
+	if strings.TrimSpace(string(req.Body)) != want {
+		t.Errorf("body = %s, want %s", req.Body, want)
+	}
+}
+
+func TestPostmarkServerAPI_ErrorSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"ErrorCode":300,"Message":"Invalid webhook URL"}`))
+	}))
+	defer srv.Close()
+
+	api := &postmarkServerAPI{Token: "t", BaseURL: srv.URL, Client: srv.Client()}
+	_, err := api.CreateWebhook(context.Background(), postmarkWebhookRequest{})
+	if err == nil {
+		t.Fatal("expected error on 422")
+	}
+	if !strings.Contains(err.Error(), "422") || !strings.Contains(err.Error(), "Invalid webhook URL") {
+		t.Errorf("error should carry status and provider message, got: %v", err)
+	}
+}
+
+func TestEventReceiver(t *testing.T) {
+	rec := newEventReceiver("shared-secret")
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	body := []byte(`{"event":"hard_bounce","submission_id":"sub-1","endpoint":"/validate/bounce","recipient":"hardbounce@bounce-testing.postmarkapp.com"}`)
+	mac := hmac.New(sha256.New, []byte("shared-secret"))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	post := func(sig string) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(body))
+		req.Header.Set("X-Posthorn-Signature", sig)
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("receiver answered %d, want 200", resp.StatusCode)
+		}
+	}
+
+	post(sig)
+	ev := <-rec.Events
+	if !ev.SignatureOK {
+		t.Error("valid signature reported as failed")
+	}
+	if ev.Event != "hard_bounce" || ev.SubmissionID != "sub-1" || ev.Endpoint != "/validate/bounce" {
+		t.Errorf("event fields not parsed: %+v", ev)
+	}
+
+	post("sha256=0000")
+	ev = <-rec.Events
+	if ev.SignatureOK {
+		t.Error("invalid signature reported as OK")
+	}
+}
+
+// TestLifecycleValidationConfig proves the generated config is one the
+// real loader accepts (storage + lifecycle + two webhook-bearing
+// endpoints), that the env placeholder resolves, and that the server
+// token never appears literally in the rendered TOML (NFR3 discipline:
+// the only on-disk reference is the ${env...} placeholder).
+func TestLifecycleValidationConfig(t *testing.T) {
+	const sentinel = "sentinel-postmark-token-8a1"
+	t.Setenv("POSTMARK_SERVER_TOKEN", sentinel)
+
+	dir := t.TempDir()
+	rendered := lifecycleValidationConfig(lifecycleValidationOpts{
+		DBPath:        filepath.Join(dir, "validate.db"),
+		BasicAuthUser: "lifecycle-user",
+		BasicAuthPass: "lifecycle-pass-0123456789",
+		From:          "validator@example.com",
+		DeliveryTo:    "inbox@example.com",
+		WebhookURL:    "http://127.0.0.1:9999/events",
+		WebhookSecret: "webhook-secret-0123456789",
+	})
+
+	if strings.Contains(rendered, sentinel) {
+		t.Fatal("rendered config contains the literal server token; it must stay an env placeholder")
+	}
+
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(rendered), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("config.Load rejected the generated config: %v\n---\n%s", err, rendered)
+	}
+
+	if cfg.Storage == nil || cfg.Lifecycle == nil {
+		t.Fatal("storage or lifecycle block missing after load")
+	}
+	if len(cfg.Endpoints) != 2 {
+		t.Fatalf("endpoints = %d, want 2", len(cfg.Endpoints))
+	}
+	if cfg.Endpoints[0].Path != "/validate/delivery" || cfg.Endpoints[1].Path != "/validate/bounce" {
+		t.Errorf("endpoint paths = %q, %q", cfg.Endpoints[0].Path, cfg.Endpoints[1].Path)
+	}
+	if got := cfg.Endpoints[1].To[0]; got != postmarkHardBounceAddress {
+		t.Errorf("bounce endpoint to = %q, want the Postmark blackhole address", got)
+	}
+	for i, ep := range cfg.Endpoints {
+		if ep.WebhookURL == "" || ep.WebhookSecret == "" {
+			t.Errorf("endpoints[%d]: webhook_url/webhook_secret not set", i)
+		}
+		if got := ep.Transport.Settings["api_key"]; got != sentinel {
+			t.Errorf("endpoints[%d]: api_key env placeholder resolved to %v, want sentinel", i, got)
+		}
+	}
+}

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -481,3 +481,82 @@ A malicious DATA blob with a `Bcc:` header in the MIME body must NOT result in a
 - Recipient cap (set low; test with N+1 RCPT TO) → 452 4.5.3
 - MIME `Bcc:` header smuggled in DATA does NOT cause delivery to the smuggled address
 - `smtp_submission_sent` log line carries `submission_id` + `transport_message_id` (when upstream provides one)
+
+## v2.0 lifecycle live validation (Story 18.3)
+
+The v2.0 lifecycle loop (Postmark events in → normalize → forward signed →
+auto-suppress, FR82–FR87) is the first surface a third party POSTs into, so
+its release validation runs against **live Postmark webhook senders** — the
+hermetic suite fakes Postmark's side and cannot prove reachability, auth,
+or real event timing.
+
+The validation is fully scripted and needs **no standing infrastructure**:
+it builds the posthorn binary, runs it locally against a generated
+config (storage + lifecycle enabled), exposes it through an anonymous
+cloudflared quick tunnel (no Cloudflare account; ephemeral
+`trycloudflare.com` URL), registers a webhook on your Postmark server via
+the Postmark API, and asserts the full loop. One command:
+
+```bash
+POSTMARK_SERVER_TOKEN=$(pass show posthorn/validation-server-token) \
+  make validate-lifecycle
+```
+
+### What one run proves
+
+1. A real send through the built binary reaches Postmark (delivery leg).
+2. Postmark's **Delivery** webhook lands on `/events/postmark` through the
+   tunnel, passes basic auth (FR82), correlates by message ID (FR83), and
+   arrives at the endpoint's `webhook_url` with a valid
+   `X-Posthorn-Signature` HMAC, verified independently (FR84).
+3. A send to `hardbounce@bounce-testing.postmarkapp.com` — Postmark's
+   documented blackhole, which bounces for real without touching sender
+   reputation — produces a **hard_bounce** event end-to-end the same way.
+4. The bounce auto-inserts a suppression row (FR85); a follow-up send
+   answers `200 {"status":"suppressed"}` with reason `hard_bounce` (FR86).
+5. `posthorn suppressions list` shows the row (FR87).
+
+### Prerequisites
+
+| What | Where to get it |
+|---|---|
+| `POSTMARK_SERVER_TOKEN` (env) | Postmark dashboard → Servers → API Tokens. **Recommended:** create a dedicated server named `posthorn-validation` first, so validation traffic and its deliberate bounces stay out of production activity. Sender signatures are account-wide; no re-verification needed. |
+| `POSTHORN_TEST_FROM` (env) | A verified sender signature on that Postmark account (dashboard → Sender Signatures). |
+| `POSTHORN_TEST_TO` (env) | A real mailbox you control that accepts mail — the Delivery event only fires after the receiving server accepts. |
+| `cloudflared` on PATH | <https://github.com/cloudflare/cloudflared/releases> (single static binary; `apt`/`brew` also carry it). No account, no login — quick tunnels are anonymous. |
+
+Postmark-side suppression of the blackhole address (which Postmark adds
+after each fake bounce) is cleared automatically at the start of every
+run, as are webhook registrations leaked by crashed prior runs (any
+registration pointing at a `trycloudflare.com` URL is dead by definition).
+
+### In CI
+
+[`lifecycle-live.yml`](../.github/workflows/lifecycle-live.yml) runs the
+same command on manual dispatch and on every `v*-rc*` tag push, behind the
+protected `live-providers` Environment (same fencing as the provider
+battery: never on pull requests). Add `POSTMARK_SERVER_TOKEN` as an
+environment secret there; `POSTHORN_TEST_FROM`/`POSTHORN_TEST_TO` are the
+existing repo variables. **If the secret is absent the test skips and the
+job still goes green** — read the log, not just the badge, when using a
+run as release evidence.
+
+### Pass criteria
+
+- `delivered` and `hard_bounce` events both arrive at the receiver with
+  valid HMAC signatures and the correct originating endpoint
+- Follow-up send to the bounced address returns `status: "suppressed"`
+  with reason `hard_bounce`
+- `posthorn suppressions list` includes the blackhole address
+- Teardown deletes the Postmark webhook registration (verify in the
+  dashboard if the run was interrupted; the next run also self-heals)
+
+### Known limits
+
+- The quick tunnel has no SLA (it is Cloudflare's dev/test tier); a
+  tunnel-establishment failure is an environment problem, not a Posthorn
+  regression — re-run, or run from a network that allows outbound QUIC
+  (7844) or HTTPS fallback.
+- The validation exercises Postmark only, matching the ADR-22 v2.0 slice.
+  Provider battery coverage for the other transports remains
+  `make test-live` (see "Live-provider validation" in CONTRIBUTING.md).

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -537,9 +537,11 @@ same command on manual dispatch and on every `v*-rc*` tag push, behind the
 protected `live-providers` Environment (same fencing as the provider
 battery: never on pull requests). Add `POSTMARK_SERVER_TOKEN` as an
 environment secret there; `POSTHORN_TEST_FROM`/`POSTHORN_TEST_TO` are the
-existing repo variables. **If the secret is absent the test skips and the
-job still goes green** — read the log, not just the badge, when using a
-run as release evidence.
+existing repo variables. Missing-secret behavior differs by trigger: on
+**manual dispatch** the test skips (green job, nothing validated — read
+the log), but on an **rc tag** the job fails outright, because a tag's
+run is release evidence and a skipped gate must never read as a green
+one.
 
 ### Pass criteria
 

--- a/spec/02-prd.md
+++ b/spec/02-prd.md
@@ -640,6 +640,7 @@ Original definition of done was a Caddy v2 adapter module wrapping the core hand
 - **Story 18.1:** Data-at-rest operator page (NFR31); deployment-shape note for lifecycle.
 - **Story 18.2:** Capability matrix, CHANGELOG, README refresh, roadmap page.
 - **Story 18.3:** Live validation pass (Postmark events end-to-end; provider battery re-run), tag `v2.0.0`.
+  - *Amended 2026-09-09:* the Postmark end-to-end leg is scripted, not manual — `make validate-lifecycle` runs the built binary locally, exposes it via an anonymous cloudflared quick tunnel, registers the webhook through the Postmark API, and asserts delivery + hard-bounce + suppression (FR82–FR87). Deliberately runnable by anyone with a Postmark server token and independent of any specific deployment: release validation is a project property, not an operator's-infrastructure property. Procedure in [docs/manual-test.md](../docs/manual-test.md); CI trigger on `v*-rc*` tags via `lifecycle-live.yml`.
 
 ## Out of scope (re-stated for clarity)
 


### PR DESCRIPTION
## Summary

Story 18.3's Postmark end-to-end leg, built as a **runnable validation instead of a manual box procedure** — deliberately independent of any specific deployment. One command proves the whole FR82–FR87 loop against live Postmark:

```bash
POSTMARK_SERVER_TOKEN=... make validate-lifecycle
```

What one run proves, in order:
1. Real send through the built binary reaches Postmark (delivery leg)
2. Postmark's Delivery webhook lands on `/events/postmark` through an anonymous cloudflared quick tunnel, passes basic auth (FR82), correlates (FR83), and reaches the endpoint's `webhook_url` with a valid `X-Posthorn-Signature`, verified independently of `core/lifecycle` (FR84)
3. Send to Postmark's documented blackhole (`hardbounce@bounce-testing.postmarkapp.com`) produces a real hard_bounce event end-to-end — no reputation impact
4. The bounce auto-suppresses; follow-up send answers `200 {"status":"suppressed"}` with reason `hard_bounce` (FR85/86)
5. `posthorn suppressions list` shows the row (FR87)

Run hygiene: provider-side suppression of the blackhole address and stale `trycloudflare.com` webhook registrations are cleared at start, so crashed runs self-heal.

## Design

- Only secret is `POSTMARK_SERVER_TOKEN`; absent → skip, same convention as the `-tags integration` live tier. Token reaches the posthorn process via `${env...}` placeholder — never written to disk (NFR3 sentinel test included).
- Helpers (Postmark webhook/suppressions API client, tunnel URL parser, HMAC verifier, event receiver, config generator) are untagged and hermetically tested on every PR, including `config.Load` accepting the generated config. Only the orchestration is behind `-tags lifecyclelive`.
- `lifecycle-live.yml`: manual dispatch + `v*-rc*` tag push, behind the `live-providers` Environment, never on pull_request — same fencing as `integration-live.yml`. cloudflared pinned by version + sha256 (#56 discipline). Cutting an rc tag runs its own release-gate validation.

## Story / FR / NFR

Story 18.3; exercises FR82–FR87; NFR3 discipline on the new secret. PRD Story 18.3 amended to record the scripted, deployment-independent approach.

## Test plan

- [x] `go vet ./...`, gofmt gate, `golangci-lint` (default + `--build-tags lifecyclelive`) clean
- [x] `go test -race ./...` passes — new hermetic tests cover the API client wire shapes, signature verification, receiver, tunnel-URL parsing, and generated-config loading
- [x] Tagged test compiles and skips cleanly without `POSTMARK_SERVER_TOKEN`
- [ ] First live run pending `POSTMARK_SERVER_TOKEN` in the `live-providers` Environment (maintainer step — see docs/manual-test.md §"v2.0 lifecycle live validation")

🤖 Generated with [Claude Code](https://claude.com/claude-code)